### PR TITLE
Add ability to use tensorizer from shell

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,4 +20,9 @@ setup(
         'Operating System :: OS Independent',
     ],
     python_requires='>=3.6',
+    entry_points={
+        'console_scripts': [
+            'tensorizer = tensorizer.tensorizer:main',
+        ],
+    },
 )

--- a/test_tensorizer.py
+++ b/test_tensorizer.py
@@ -1,5 +1,5 @@
-import os
-import tensorizer
+from tensorizer import tensorizer
+
 import unittest
 import torch
 


### PR DESCRIPTION
This is mainly to be used in a future Docker image so models can be serialized in a container (launched as a kube job) since the serialization process is quite resource intensive in reference to https://github.com/coreweave/tensorizer/issues/8