### PR TITLE
Many bug fixes and enhancements

### DIFF
--- a/tensorizer/_wide_pipes.py
+++ b/tensorizer/_wide_pipes.py
@@ -1,0 +1,158 @@
+import contextlib
+import functools
+import logging
+import threading
+import subprocess
+import sys
+
+# =============================================================================
+# From `pipe(7)` manpage:
+#
+# Pipe capacity
+# A pipe has a limited capacity. If the pipe is full, then a write(2) will
+# block or fail, depending on whether the O_NONBLOCK flag is set (see below).
+# Different implementations have different limits for the pipe capacity.
+#
+# Applications should not rely on a particular capacity: an application should
+# be designed so that a reading process consumes data as soon as it is
+# available, so that a writing process does not remain blocked.
+#
+# In Linux versions before 2.6.11, the capacity of a pipe was the same as the
+# system page size (e.g., 4096 bytes on i386). Since Linux 2.6.11, the pipe
+# capacity is 16 pages (i.e., 65,536 bytes in a system with a page size of
+# 4096 bytes). Since Linux 2.6.35, the default pipe capacity is 16 pages, but
+# the capacity can be queried and set using the fcntl(2) F_GETPIPE_SZ and
+# F_SETPIPE_SZ operations. See fcntl(2) for more information.
+#
+# =============================================================================
+# From `fcntl(2)` manpage:
+#
+# Changing the capacity of a pipe
+#
+# F_SETPIPE_SZ (int; since Linux 2.6.35)
+# Change the capacity of the pipe referred to by fd to be at least arg bytes.
+# An unprivileged process can adjust the pipe capacity to any value between the
+# system page size and the limit defined in /proc/sys/fs/pipe−max−size
+# (see proc(5)). Attempts to set the pipe capacity below the page size are
+# silently rounded up to the page size. Attempts by an unprivileged process to
+# set the pipe capacity above the limit in /proc/sys/fs/pipe−max−size yield the
+# error EPERM; a privileged process (CAP_SYS_RESOURCE) can override the limit.
+#
+# When allocating the buffer for the pipe, the kernel may use a capacity larger
+# than arg, if that is convenient for the implementation. (In the current
+# implementation, the allocation is the next higher power-of-two page-size
+# multiple of the requested size.) The actual capacity (in bytes) that is set
+# is returned as the function result.
+#
+# Attempting to set the pipe capacity smaller than the amount of buffer space
+# currently used to store data produces the error EBUSY.
+#
+# Note that because of the way the pages of the pipe buffer are employed when
+# data is written to the pipe, the number of bytes that can be written may be
+# less than the nominal size, depending on the size of the writes.
+#
+# F_GETPIPE_SZ (void; since Linux 2.6.35)
+# Return (as the function result) the capacity of the pipe referred to by fd.
+#
+# =============================================================================
+# Constant for `F_SETPIPE_SZ`, as Python's `fcntl` module doesn't have this
+# defined until Python 3.10.
+F_SETPIPE_SZ = 1031
+
+_logger = logging.getLogger(__name__)
+
+__all__ = "get_max_pipe_size", "widen_pipe", "widen_new_pipes"
+
+# No-op default implementations
+widen_new_pipes = contextlib.ExitStack
+
+
+def widen_pipe(_fileno):
+    pass
+
+
+@functools.lru_cache(maxsize=None)
+def get_max_pipe_size():
+    pipe_buf_sz = 1024 * 1024
+    if sys.platform != "win32":
+        # Read our max-fd-size, fall back to 1mb if invalid.
+        try:
+            pipe_file = open("/proc/sys/fs/pipe-max-size", "r")
+            pipe_buf_sz = int(pipe_file.read())
+        except IOError as e:
+            _logger.warning(
+                f"Could not read /proc/sys/fs/pipe-max-size: {e.strerror}"
+            )
+    else:
+        # Windows has no maximum pipe size,
+        # so 256 MiB is chosen completely arbitrarily.
+        pipe_buf_sz = 256 * 1024 * 1024
+    _logger.debug(f"pipe-max-size: {pipe_buf_sz}")
+    return pipe_buf_sz
+
+
+if sys.platform != "win32":
+    # Linux uses fcntl to resize an existing pipe.
+    import fcntl
+
+    def widen_pipe(fileno):
+        pipe_buf_sz = get_max_pipe_size()
+        try:
+            fcntl.fcntl(fileno, F_SETPIPE_SZ, pipe_buf_sz)
+        except PermissionError as e:
+            _logger.warning(
+                f"Couldn't fcntl F_SETPIPE_SZ to {pipe_buf_sz}: {e.strerror}"
+            )
+else:
+    # Windows cannot change the size of a pipe after creation,
+    # but it can set one's size during creation, so a context manager
+    # is used to temporarily modify the creation of all pipes.
+    _winapi = getattr(subprocess, "_winapi", None)
+    if _winapi is not None and hasattr(_winapi, "CreatePipe"):
+        class _LocalPipeSize(threading.local):
+            pipe_size = 0
+        _local = _LocalPipeSize()
+        _original_create_pipe = _winapi.CreatePipe
+        _pipe_routine_swap_mutex = threading.Lock()
+        _pipe_widening_threads = 0
+
+        def _create_wide_pipe(pipe_attrs, size):
+            # The subprocess module creates new anonymous pipes on Windows as:
+            # _winapi.CreatePipe(None, 0)
+            # Where the first argument is ignored,
+            # and the second is the pipe size (0 = default, usually 1 page).
+            # To change this without reimplementing all of subprocess.Popen,
+            # _winapi.CreatePipe itself is wrapped to override a size of 0
+            # with a default of our choosing.
+            #
+            # This function is thread-safe in the sense that other threads
+            # creating pipes while this is active will end up with
+            # unchanged results due to the override value being thread-local.
+            return _original_create_pipe(
+                pipe_attrs, _local.pipe_size if size == 0 else size
+            )
+
+        @contextlib.contextmanager
+        def widen_new_pipes():
+            global _pipe_widening_threads
+            # Thread-safe but not re-entrant.
+            # Thread safety in this function only matters if multiple threads
+            # try to separately invoke this context manager at the same time,
+            # which would only happen if multiple CURLStreamFiles were being
+            # opened in the same process at the same time. It is less important
+            # than _create_wide_pipe being thread-safe.
+            _local.pipe_size = get_max_pipe_size()
+            with _pipe_routine_swap_mutex:
+                _winapi.CreatePipe = _create_wide_pipe
+                _pipe_widening_threads += 1
+            try:
+                yield
+            finally:
+                with _pipe_routine_swap_mutex:
+                    _pipe_widening_threads -= 1
+                    if _pipe_widening_threads == 0:
+                        _winapi.CreatePipe = _original_create_pipe
+                del _local.pipe_size
+
+    else:
+        _logger.warning("Couldn't increase default pipe size.")

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -2,7 +2,6 @@
 # serialization.py                                                   Wes Brown
 # Fast torch module/model serialization/deserialization     (c) 2023 Coreweave
 ##############################################################################
-import mmap
 
 # try to import UNIX only dependencies
 try:
@@ -27,7 +26,7 @@ import tempfile
 import regex
 
 from collections import OrderedDict
-from typing import Optional, Tuple, Union, List, Iterator, Callable, Dict, Any
+from typing import Optional, Tuple, Union, List, Iterator, Dict
 
 lz4 = None
 
@@ -147,6 +146,7 @@ class TensorDeserializer:
 
     def __del__(self):
         self.close()
+
     def close(self):
         if self._mmap is not None:
             self._mmap.close()
@@ -192,7 +192,6 @@ class TensorDeserializer:
             dtype=dtype,
             shape=shape,
         )
-
 
     def _read_metadatas(self):
         """
@@ -314,7 +313,7 @@ class TensorDeserializer:
                     self._file.seek(mmap_offset + data_length)
                     continue
 
-                mv: Union[memoryview, None] = None
+                mv: memoryview
                 if self._mmap is not None:
                     mmap_offset = self._mmap_file.tell()
                     mv = memoryview(self._mmap)[mmap_offset:data_length+mmap_offset]
@@ -322,7 +321,7 @@ class TensorDeserializer:
                     self._mmap_file.seek(data_length, 1)
                 elif self._oneshot:
                     if data_length > len(self._buffer):
-                         self._buffer = bytearray(data_length)
+                        self._buffer = bytearray(data_length)
                     mv = memoryview(self._buffer)
                     self._file.readinto(mv[:data_length])
                 else:

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -148,10 +148,12 @@ class TensorDeserializer:
         self.close()
 
     def close(self):
-        if self._mmap is not None:
+        # Don't throw an attribute error if these aren't defined yet,
+        # e.g. if __init__ threw an error before defining both
+        if getattr(self, "_mmap", None) is not None:
             self._mmap.close()
             self._mmap_file.close()
-        if self._file is not None:
+        if getattr(self, "_file", None) is not None:
             self._file.close()
 
     def _read_string(self, io_obj=None):

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -309,7 +309,7 @@ class TensorDeserializer:
                 data_length = struct.unpack("<q", headers[header_len - 8:])[0]
                 # Check if the name matches the pattern, drop if it doesn't.
                 if pattern is not None and not pattern.match(name):
-                    self._file.seek(mmap_offset + data_length)
+                    self._file.seek(data_length, io.SEEK_CUR)
                     continue
 
                 mv: memoryview

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -349,9 +349,9 @@ class TensorDeserializer:
         """
         Convert a numpy array to a torch tensor on a device.
         """
-        gradient = arr.dtype.kind in ("f", "c")
         if dtype is not None and arr.dtype != "bool" and arr.dtype != dtype:
             arr = arr.astype(dtype)
+        gradient = arr.dtype.kind in ("f", "c")
 
         return torch.nn.Parameter(
             torch.as_tensor(arr, device=device), requires_grad=gradient

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -124,8 +124,7 @@ class TensorDeserializer:
         self._mmap = None
         if use_mmap:
             self._mmap_file = tempfile.TemporaryFile("wb+")
-            self._mmap_file.write(b"\0" * self.total_tensor_bytes)
-            self._mmap_file.seek(0)
+            self._mmap_file.truncate(self.total_tensor_bytes)
             self._mmap = mmap.mmap(self._mmap_file.fileno(), self.total_tensor_bytes)
 
         self._cache: Dict[str, torch.Tensor] = {}

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -145,10 +145,9 @@ class CURLStreamFile:
                 ret_buff = ba
         if ret_buff_sz != rq_sz:
             self.closed = True
-            err = self._curl.stderr.read()
             self._curl.terminate()
             if self._curl.returncode != 0:
-                raise IOError(f"curl error: {self._curl.returncode}, {err}")
+                raise IOError(f"curl error: {self._curl.returncode}")
             else:
                 raise IOError(f"Requested {rq_sz} != {ret_buff_sz}")
         self._curr += ret_buff_sz

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -170,7 +170,7 @@ class CURLStreamFile(object):
 
         if begin is not None or end is not None:
             if begin is None:
-                begin_pos = 0
+                begin = 0
             if end is None:
                 end = ""
             cmd.extend(["--range", f"{begin}-{end}"])

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -8,7 +8,7 @@ import typing
 from urllib.parse import urlparse
 
 import boto3
-from io import SEEK_SET, SEEK_END
+from io import SEEK_SET, SEEK_CUR, SEEK_END
 from typing import Union, Optional, Dict, Any
 import requests
 import shutil
@@ -71,7 +71,7 @@ class CURLStreamFile:
     """
     CURLStreamFile implements a file-like object around an HTTP download, the
     intention being to not buffer more than we have to. It is intended for
-    tar-like files, where we start at the begining and read until the end of
+    tar-like files, where we start at the beginning and read until the end of
     the file.
 
     It does implement `seek` and `tell`, but only for the purpose of
@@ -197,6 +197,8 @@ class CURLStreamFile:
     """
 
     def seek(self, position, whence=SEEK_SET):
+        if whence == SEEK_CUR:
+            position += self._curr
         if position == self._curr:
             return
         if whence == SEEK_END:
@@ -283,6 +285,8 @@ class RequestsStreamFile:
     """
 
     def seek(self, position, whence=SEEK_SET):
+        if whence == SEEK_CUR:
+            position += self._curr
         if position == self._curr:
             return
         if whence == SEEK_END:

--- a/tensorizer/utils.py
+++ b/tensorizer/utils.py
@@ -1,5 +1,9 @@
-import resource
 import torch
+try:
+    import resource
+except ImportError:
+    resource = None
+
 
 # Silly function to convert to human bytes
 def convert_bytes(num):
@@ -13,8 +17,10 @@ def convert_bytes(num):
             return "%3.1f %s" % (num, x)
         num /= step_unit
 
+
 def get_device() -> torch.device:
     return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
 
 def get_ram_usage_str() -> str:
     if resource is not None:
@@ -41,6 +47,7 @@ def get_gpu_name() -> str:
     if torch.cuda.is_available():
         return torch.cuda.get_device_name(0)
     return "N/A"
+
 
 def no_init_or_tensor(loading_code):
     def dummy(self):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -72,21 +72,21 @@ class TestSerialization(unittest.TestCase):
         print(f"After deserialization: {after_deserialization}")
 
     def test_mmap_gpu(self):
-        before_serialization = utils.get_vram_ram_usage_str()
+        before_serialization = utils.get_mem_usage()
         serialized_model, orig_sd = serialize_model(model_name, device="cuda")
-        after_serialization = utils.get_vram_ram_usage_str()
+        after_serialization = utils.get_mem_usage()
         in_file = open(serialized_model, "rb")
         deserialized = TensorDeserializer(in_file,
                                           device="cuda",
                                           use_mmap=True)
-        after_deserialization = utils.get_vram_ram_usage_str()
+        after_deserialization = utils.get_mem_usage()
         check_deserialized(deserialized, orig_sd)
         print(f"Before serialization: {before_serialization}")
         print(f"After serialization: {after_serialization}")
         print(f"After deserialization: {after_deserialization}")
         del serialized_model, orig_sd, in_file
         gc.collect()
-        after_del = utils.get_vram_ram_usage_str()
+        after_del = utils.get_mem_usage()
         print(f"After del: {after_del}")
 
     def test_mmap_preload(self):

--- a/tests/test_stream_io.py
+++ b/tests/test_stream_io.py
@@ -3,6 +3,7 @@ from tensorizer import stream_io
 
 NEO_URL = "https://raw.githubusercontent.com/EleutherAI/gpt-neo/master/README.md"
 
+
 class TestCurlStream(unittest.TestCase):
     def test_curl_stream(self):
         stream = stream_io.CURLStreamFile(NEO_URL)


### PR DESCRIPTION
## Summary
This PR contains many bug fixes and compatibility enhancements across the package for the tensorizer rework. Notably, this branch implements full Windows support at this time, and obviates the need for a `RequestsStreamFile` implementation.

## Bug fixes
Almost all bug fixes are isolated in their own commit for more details:
- 615479038258e2ef770966a64e73b1074aea0f01 Fixes .s3cfg handling
- 064e1f582b8347daba7e7775f48d8b53121d6459 Fixes `begin` offsets in `CURLStreamFile`
- 3b5b35b17b5dd94de40dda1ae0883d29ebd7e5b1 Fixes various bugs when requesting unsupported modes from `stream_io` streams
- 6f0f230e5f9f9944e92e1870a05c84cdf851019b Fixes a case where writing to `s3://` streams could trigger two uploads of the same data, and properly cleans up temporary files
- ad48943bb04bdf4157441b8ee1d77d4b74046b34 Adds more narrowly typed exceptions to `stream_io` (i.e. no more bare `Exception`s)
- 423c2ffd8531d891207facffbe27e03ffb4eeb30 Fixes cross-platform incompatibilities, as well as a `TypeError` when specifying a `begin` but no `end` with a `CURLStreamFile`
- aa19e46bdc52e2aa04f43d066d7354bede815198 Ports [updates to `get_mem_usage`](https://github.com/coreweave/kubernetes-cloud/commit/8db478c7da86ae3eb5802cd3d7fafa0bbfb3c0b8#diff-2df704c550ff8c11d9a039399e5469047a84f6d878201b06804dc57cfd437856R324-R353) from `coreweave/kubernetes-cloud@wbrown.finetuning-sampling`, makes the function cross-platform, and makes pynvml only a necessary dependency when using PyTorch versions below v1.10.0
- 003973b7dd047168a1783e8585702e148caee99b Fixes `CURLStreamFile` `curl` error handling
- 6cc50633e821badb3e29fcd36dfc83c6a0206b45 Prevents cascading errors in `TensorDeserializer.__del__()` when `TensorDeserializer.__init__()` fails
- e802d5a06d67dc558f9db3033c612dd36e9416ee Fixes cases both where autograd-capable parameters could be marked with `requires_grad=False` and where autograd-incapable parameters could be marked with `requires_grad=True`
- fde3772a28cc8b365dbb3921cfbd9778f571a2ee Fixes invalid test cases and optimizes the rest by sharing a pre-serialized model file for all deserialization tests, as well as cleaning up temporary files generated within unit tests
- e302d8d5519c2d2197f69f8fc9486212761d915b Fixes invalid behaviour when `io.SEEK_CUR` is passed to a `CURLStreamFile`
- 4c2a5b1bec6c7d14eec6fa770646d5f1ae2d1078 Fixes invalid seeking when skipping tensors that don't match the `pattern` provided during deserialization.