### PR TITLE
Allow unspecified credentials for public-read buckets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorizer"
-version = "1.0.0"
+version = "1.0.1"
 license = { text = "MIT License" }
 keywords = ["tensorizer", "machine learning", "serialization", "tensor", "pytorch"]
 authors = [

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -45,9 +45,12 @@ def check_deserialized(deserialized, model_name: str, allow_subset=False):
     if not allow_subset:
         assert orig_sd.keys() == deserialized.keys()
     for k, v in deserialized.items():
-        assert k in orig_sd
-        assert v.size() == orig_sd[k].size()
-        assert v.dtype == orig_sd[k].dtype
+        assert k in orig_sd, \
+            f"{k} not in {orig_sd.keys()}"
+        assert v.size() == orig_sd[k].size(), \
+            f"{v.size()} != {orig_sd[k].size()}"
+        assert v.dtype == orig_sd[k].dtype, \
+            f"{v.dtype} != {orig_sd[k].dtype}"
         assert torch.all(orig_sd[k].to(v.device) == v)
     del orig_sd
     gc.collect()

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -215,7 +215,10 @@ class TestDeserialization(unittest.TestCase):
             f"s3://tensorized/{model_name}/fp16/model.tensors",
             device=default_device,
         )
-        check_inference(deserialized, model_name, default_device)
+        assert deserialized.total_tensor_bytes > 0
+        if is_cuda_available and default_device != "cpu":
+            # FP16 tensors don't work correctly on CPU in PyTorch
+            check_inference(deserialized, model_name, default_device)
         deserialized.close()
 
     def test_s3_lazy_load(self):


### PR DESCRIPTION
# Allow unspecified credentials for public-read buckets

To make the default behaviour of `stream_io.open_stream()` more ergonomic for the common use case of specifying an `s3://` URI pointing to a public-read bucket, downloads (but not uploads) now tentatively attempt to proceed with blank credentials if none were specified and no s3cmd config file was found, and include a descriptive error message warning that blank credentials were used only if this leads to the download failing later on.

This approach avoids having to check credentials pre-emptively, prevents warning spam for that use case, and doesn't swallow up errors about invalid config files when they were intended to be used.

Additionally, cURL errors from `CURLStreamFile` now attempt to include cURL's own error text when possible, including HTTP error codes.