### PR TITLE
Improve examples, docs, and code style, and add `no_init_or_tensor()` context manager and more memory utils.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+exclude: ^.*_pb2\.py|ATTIC/.*$
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.3.0
+    hooks:
+      - id: black
+        language_version: python3.10
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        args: ["--filter-files"]

--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ python -m pip install transformers accelerate
 
 [serialize.py](examples/serialize.py)
 ```python
-from transformers import AutoModelForCausalLM
-from tensorizer import TensorSerializer
 import torch
+from tensorizer import TensorSerializer
+from transformers import AutoModelForCausalLM
 
 model_ref = "EleutherAI/gpt-j-6B"
 # For less intensive requirements, swap above with the line below:
@@ -125,8 +125,8 @@ endpoint.
 
 [deserialize.py](examples/deserialize.py)
 ```python
-import torch
 import time
+import torch
 from tensorizer import TensorDeserializer
 from tensorizer.utils import no_init_or_tensor, convert_bytes, get_mem_usage
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ credentials in `~/.s3cfg`.
 **NOTE:** Loading and serializing `gpt-j-6B` will take a lot of CPU RAM,
 up to `~20GB`. Additionally, when loading `gpt-j-6B` into a GPU, you
 will need about `~16GB` of VRAM. If you don't have that much RAM or VRAM,
-you can use the smaller `gpt-neo-125m` model instead.
+you can use the smaller `gpt-neo-125M` model instead.
 
 **NOTE2:** The below examples require the `transformers` and `accelerate`
 libraries. You can install them with `pip`:
@@ -94,7 +94,7 @@ import torch
 
 model_ref = "EleutherAI/gpt-j-6B"
 # For less intensive requirements, swap above with the line below:
-# model_ref = "EleutherAI/gpt-neo-125m"
+# model_ref = "EleutherAI/gpt-neo-125M"
 model_name = model_ref.split("/")[-1]
 # Change this to your S3 bucket.
 s3_bucket = "bucket"
@@ -139,7 +139,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer, AutoConfig
 
 model_ref = "EleutherAI/gpt-j-6B"
 # To run this at home, swap this with the line below for a smaller example:
-# model_ref = "EleutherAI/gpt-neo-125m"
+# model_ref = "EleutherAI/gpt-neo-125M"
 model_name = model_ref.split("/")[-1]
 # Change this to your S3 bucket.
 s3_bucket = "bucket"

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ and `hf_main()` serializes
 
 The following models are available on the CoreWeave Cloud for free, and can be
 used with the `TensorDeserializer` class. The S3 support defaults to the
-`accel-object.ord1.coreweave.com` endpoint, and the bucket to use `tensorized`.
+`accel-object.ord1.coreweave.com` endpoint, and the bucket to use as `tensorized`.
 
 We name the keys in the S3 bucket after the HuggingFace model identifier, and
 append the `/fp16` suffix for the half-precision version.

--- a/README.md
+++ b/README.md
@@ -212,62 +212,62 @@ The below table shows the available models and their S3 URIs.
 
 ### Large Language Models
 
-| Model                                                                     | Precision | S3 URI  |
-|---------------------------------------------------------------------------|-----------|---------|
-| [EleutherAI/gpt-neo-125M](https://huggingface.co/EleutherAI/gpt-neo-125M) | `fp32`    | `s3://tensorized/EleutherAI/gpt-neo-125M/model.tensors` |
-| [EleutherAI/gpt-neo-125M](https://huggingface.co/EleutherAI/gpt-neo-125M) | `fp16`    | `s3://tensorized/EleutherAI/gpt-neo-125M/fp16/model.tensors` |
-| [EleutherAI/gpt-neo-1.3B](https://huggingface.co/EleutherAI/gpt-neo-1.3B) | `fp32`    | `s3://tensorized/EleutherAI/gpt-neo-1.3B/model.tensors` |
-| [EleutherAI/gpt-neo-1.3B](https://huggingface.co/EleutherAI/gpt-neo-1.3B) | `fp16`    | `s3://tensorized/EleutherAI/gpt-neo-1.3B/fp16/model.tensors` |
-| [EleutherAI/gpt-neo-2.7B](https://huggingface.co/EleutherAI/gpt-neo-2.7B) | `fp32`    | `s3://tensorized/EleutherAI/gpt-neo-2.7B/model.tensors` |
-| [EleutherAI/gpt-neo-2.7B](https://huggingface.co/EleutherAI/gpt-neo-2.7B) | `fp16`    | `s3://tensorized/EleutherAI/gpt-neo-2.7B/fp16/model.tensors` |
-| [EleutherAI/gpt-j-6B](https://huggingface.co/EleutherAI/gpt-j-6B)         | `fp32`    | `s3://tensorized/EleutherAI/gpt-j-6B/model.tensors` |
-| [EleutherAI/gpt-j-6B](https://huggingface.co/EleutherAI/gpt-j-6B)         | `fp16`    | `s3://tensorized/EleutherAI/gpt-j-6B/fp16/model.tensors` |
-| [EleutherAI/gpt-neox-20b](https://huggingface.co/EleutherAI/gpt-neox-20b) | `fp32`    | `s3://tensorized/EleutherAI/gpt-neox-20b/model.tensors` |
-| [EleutherAI/gpt-neox-20b](https://huggingface.co/EleutherAI/gpt-neox-20b) | `fp16`    | `s3://tensorized/EleutherAI/gpt-neox-20b/fp16/model.tensors` |
-| [EleutherAI/pythia-70m](https://huggingface.co/EleutherAI/pythia-70m)     | `fp32`    | `s3://tensorized/EleutherAI/pythia-70m/model.tensors` |
-| [EleutherAI/pythia-70m](https://huggingface.co/EleutherAI/pythia-70m)     | `fp16`    | `s3://tensorized/EleutherAI/pythia-70m/fp16/model.tensors` |
-| [EleutherAI/pythia-1.4b](https://huggingface.co/EleutherAI/pythia-1.4b)   | `fp32`    | `s3://tensorized/EleutherAI/pythia-1.4b/model.tensors` |
-| [EleutherAI/pythia-1.4b](https://huggingface.co/EleutherAI/pythia-1.4b)   | `fp16`    | `s3://tensorized/EleutherAI/pythia-1.4b/fp16/model.tensors` |
-| [EleutherAI/pythia-2.8b](https://huggingface.co/EleutherAI/pythia-2.8b)   | `fp32`    | `s3://tensorized/EleutherAI/pythia-2.8b/model.tensors` |
-| [EleutherAI/pythia-2.8b](https://huggingface.co/EleutherAI/pythia-2.8b)   | `fp16`    | `s3://tensorized/EleutherAI/pythia-2.8b/fp16/model.tensors` |
-| [EleutherAI/pythia-6.9b](https://huggingface.co/EleutherAI/pythia-6.9b)   | `fp32`    | `s3://tensorized/EleutherAI/pythia-6.9b/model.tensors` |
-| [EleutherAI/pythia-6.9b](https://huggingface.co/EleutherAI/pythia-6.9b)   | `fp16`    | `s3://tensorized/EleutherAI/pythia-6.9b/fp16/model.tensors` |
-| [EleutherAI/pythia-12b](https://huggingface.co/EleutherAI/pythia-12b)     | `fp32`    | `s3://tensorized/EleutherAI/pythia-12b/model.tensors` |
-| [EleutherAI/pythia-12b](https://huggingface.co/EleutherAI/pythia-12b)     | `fp16`    | `s3://tensorized/EleutherAI/pythia-12b/fp16/model.tensors` |
-| [EleutherAI/pythia-70m-deduped](https://huggingface.co/EleutherAI/pythia-70m-deduped) | `fp32`    | `s3://tensorized/EleutherAI/pythia-70m-deduped/model.tensors` |
-| [EleutherAI/pythia-70m-deduped](https://huggingface.co/EleutherAI/pythia-70m-deduped) | `fp16`    | `s3://tensorized/EleutherAI/pythia-70m-deduped/fp16/model.tensors` |
-| [EleutherAI/pythia-1.4b-deduped](https://huggingface.co/EleutherAI/pythia-1.4b-deduped) | `fp32`    | `s3://tensorized/EleutherAI/pythia-1.4b-deduped/model.tensors` |
+| Model                                                                                   | Precision | S3 URI                                                              |
+|-----------------------------------------------------------------------------------------|-----------|---------------------------------------------------------------------|
+| [EleutherAI/gpt-neo-125M](https://huggingface.co/EleutherAI/gpt-neo-125M)               | `fp32`    | `s3://tensorized/EleutherAI/gpt-neo-125M/model.tensors`             |
+| [EleutherAI/gpt-neo-125M](https://huggingface.co/EleutherAI/gpt-neo-125M)               | `fp16`    | `s3://tensorized/EleutherAI/gpt-neo-125M/fp16/model.tensors`        |
+| [EleutherAI/gpt-neo-1.3B](https://huggingface.co/EleutherAI/gpt-neo-1.3B)               | `fp32`    | `s3://tensorized/EleutherAI/gpt-neo-1.3B/model.tensors`             |
+| [EleutherAI/gpt-neo-1.3B](https://huggingface.co/EleutherAI/gpt-neo-1.3B)               | `fp16`    | `s3://tensorized/EleutherAI/gpt-neo-1.3B/fp16/model.tensors`        |
+| [EleutherAI/gpt-neo-2.7B](https://huggingface.co/EleutherAI/gpt-neo-2.7B)               | `fp32`    | `s3://tensorized/EleutherAI/gpt-neo-2.7B/model.tensors`             |
+| [EleutherAI/gpt-neo-2.7B](https://huggingface.co/EleutherAI/gpt-neo-2.7B)               | `fp16`    | `s3://tensorized/EleutherAI/gpt-neo-2.7B/fp16/model.tensors`        |
+| [EleutherAI/gpt-j-6B](https://huggingface.co/EleutherAI/gpt-j-6B)                       | `fp32`    | `s3://tensorized/EleutherAI/gpt-j-6B/model.tensors`                 |
+| [EleutherAI/gpt-j-6B](https://huggingface.co/EleutherAI/gpt-j-6B)                       | `fp16`    | `s3://tensorized/EleutherAI/gpt-j-6B/fp16/model.tensors`            |
+| [EleutherAI/gpt-neox-20b](https://huggingface.co/EleutherAI/gpt-neox-20b)               | `fp32`    | `s3://tensorized/EleutherAI/gpt-neox-20b/model.tensors`             |
+| [EleutherAI/gpt-neox-20b](https://huggingface.co/EleutherAI/gpt-neox-20b)               | `fp16`    | `s3://tensorized/EleutherAI/gpt-neox-20b/fp16/model.tensors`        |
+| [EleutherAI/pythia-70m](https://huggingface.co/EleutherAI/pythia-70m)                   | `fp32`    | `s3://tensorized/EleutherAI/pythia-70m/model.tensors`               |
+| [EleutherAI/pythia-70m](https://huggingface.co/EleutherAI/pythia-70m)                   | `fp16`    | `s3://tensorized/EleutherAI/pythia-70m/fp16/model.tensors`          |
+| [EleutherAI/pythia-1.4b](https://huggingface.co/EleutherAI/pythia-1.4b)                 | `fp32`    | `s3://tensorized/EleutherAI/pythia-1.4b/model.tensors`              |
+| [EleutherAI/pythia-1.4b](https://huggingface.co/EleutherAI/pythia-1.4b)                 | `fp16`    | `s3://tensorized/EleutherAI/pythia-1.4b/fp16/model.tensors`         |
+| [EleutherAI/pythia-2.8b](https://huggingface.co/EleutherAI/pythia-2.8b)                 | `fp32`    | `s3://tensorized/EleutherAI/pythia-2.8b/model.tensors`              |
+| [EleutherAI/pythia-2.8b](https://huggingface.co/EleutherAI/pythia-2.8b)                 | `fp16`    | `s3://tensorized/EleutherAI/pythia-2.8b/fp16/model.tensors`         |
+| [EleutherAI/pythia-6.9b](https://huggingface.co/EleutherAI/pythia-6.9b)                 | `fp32`    | `s3://tensorized/EleutherAI/pythia-6.9b/model.tensors`              |
+| [EleutherAI/pythia-6.9b](https://huggingface.co/EleutherAI/pythia-6.9b)                 | `fp16`    | `s3://tensorized/EleutherAI/pythia-6.9b/fp16/model.tensors`         |
+| [EleutherAI/pythia-12b](https://huggingface.co/EleutherAI/pythia-12b)                   | `fp32`    | `s3://tensorized/EleutherAI/pythia-12b/model.tensors`               |
+| [EleutherAI/pythia-12b](https://huggingface.co/EleutherAI/pythia-12b)                   | `fp16`    | `s3://tensorized/EleutherAI/pythia-12b/fp16/model.tensors`          |
+| [EleutherAI/pythia-70m-deduped](https://huggingface.co/EleutherAI/pythia-70m-deduped)   | `fp32`    | `s3://tensorized/EleutherAI/pythia-70m-deduped/model.tensors`       |
+| [EleutherAI/pythia-70m-deduped](https://huggingface.co/EleutherAI/pythia-70m-deduped)   | `fp16`    | `s3://tensorized/EleutherAI/pythia-70m-deduped/fp16/model.tensors`  |
+| [EleutherAI/pythia-1.4b-deduped](https://huggingface.co/EleutherAI/pythia-1.4b-deduped) | `fp32`    | `s3://tensorized/EleutherAI/pythia-1.4b-deduped/model.tensors`      |
 | [EleutherAI/pythia-1.4b-deduped](https://huggingface.co/EleutherAI/pythia-1.4b-deduped) | `fp16`    | `s3://tensorized/EleutherAI/pythia-1.4b-deduped/fp16/model.tensors` |
-| [EleutherAI/pythia-2.8b-deduped](https://huggingface.co/EleutherAI/pythia-2.8b-deduped) | `fp32`    | `s3://tensorized/EleutherAI/pythia-2.8b-deduped/model.tensors` |
+| [EleutherAI/pythia-2.8b-deduped](https://huggingface.co/EleutherAI/pythia-2.8b-deduped) | `fp32`    | `s3://tensorized/EleutherAI/pythia-2.8b-deduped/model.tensors`      |
 | [EleutherAI/pythia-2.8b-deduped](https://huggingface.co/EleutherAI/pythia-2.8b-deduped) | `fp16`    | `s3://tensorized/EleutherAI/pythia-2.8b-deduped/fp16/model.tensors` |
-| [EleutherAI/pythia-6.9b-deduped](https://huggingface.co/EleutherAI/pythia-6.9b-deduped) | `fp32`    | `s3://tensorized/EleutherAI/pythia-6.9b-deduped/model.tensors` |
+| [EleutherAI/pythia-6.9b-deduped](https://huggingface.co/EleutherAI/pythia-6.9b-deduped) | `fp32`    | `s3://tensorized/EleutherAI/pythia-6.9b-deduped/model.tensors`      |
 | [EleutherAI/pythia-6.9b-deduped](https://huggingface.co/EleutherAI/pythia-6.9b-deduped) | `fp16`    | `s3://tensorized/EleutherAI/pythia-6.9b-deduped/fp16/model.tensors` |
-| [EleutherAI/pythia-12b-deduped](https://huggingface.co/EleutherAI/pythia-12b-deduped) | `fp32`    | `s3://tensorized/EleutherAI/pythia-12b-deduped/model.tensors` |
-| [EleutherAI/pythia-12b-deduped](https://huggingface.co/EleutherAI/pythia-12b-deduped) | `fp16`    | `s3://tensorized/EleutherAI/pythia-12b-deduped/fp16/model.tensors` |
-| [KoboldAI/fairseq-dense-125M](https://huggingface.co/KoboldAI/fairseq-dense-125M) | `fp32`    | `s3://tensorized/KoboldAI/fairseq-dense-125M/model.tensors` |
-| [KoboldAI/fairseq-dense-125M](https://huggingface.co/KoboldAI/fairseq-dense-125M) | `fp16`    | `s3://tensorized/KoboldAI/fairseq-dense-125M/fp16/model.tensors` |
-| [KoboldAI/fairseq-dense-355M](https://huggingface.co/KoboldAI/fairseq-dense-355M) | `fp32`    | `s3://tensorized/KoboldAI/fairseq-dense-355M/model.tensors` |
-| [KoboldAI/fairseq-dense-355M](https://huggingface.co/KoboldAI/fairseq-dense-355M) | `fp16`    | `s3://tensorized/KoboldAI/fairseq-dense-355M/fp16/model.tensors` |
-| [KoboldAI/fairseq-dense-2.7B](https://huggingface.co/KoboldAI/fairseq-dense-2.7B) | `fp32`    | `s3://tensorized/KoboldAI/fairseq-dense-2.7B/model.tensors` |
-| [KoboldAI/fairseq-dense-2.7B](https://huggingface.co/KoboldAI/fairseq-dense-2.7B) | `fp16`    | `s3://tensorized/KoboldAI/fairseq-dense-2.7B/fp16/model.tensors` |
-| [KoboldAI/fairseq-dense-6.7B](https://huggingface.co/KoboldAI/fairseq-dense-6.7B) | `fp32`    | `s3://tensorized/KoboldAI/fairseq-dense-6.7B/model.tensors` |
-| [KoboldAI/fairseq-dense-6.7B](https://huggingface.co/KoboldAI/fairseq-dense-6.7B) | `fp16`    | `s3://tensorized/KoboldAI/fairseq-dense-6.7B/fp16/model.tensors` |
-| [KoboldAI/fairseq-dense-13B](https://huggingface.co/KoboldAI/fairseq-dense-13B) | `fp32`    | `s3://tensorized/KoboldAI/fairseq-dense-13B/model.tensors` |
-| [KoboldAI/fairseq-dense-13B](https://huggingface.co/KoboldAI/fairseq-dense-13B) | `fp16`    | `s3://tensorized/KoboldAI/fairseq-dense-13B/fp16/model.tensors` |
-| [Salesforce/codegen-350M-mono](https://huggingface.co/Salesforce/codegen-350M-mono) | `fp32`    | `s3://tensorized/Salesforce/codegen-350M-mono/model.tensors` |
-| [Salesforce/codegen-350M-mono](https://huggingface.co/Salesforce/codegen-350M-mono) | `fp16`    | `s3://tensorized/Salesforce/codegen-350M-mono/fp16/model.tensors` |
-| [Salesforce/codegen-350M-multi](https://huggingface.co/Salesforce/codegen-350M-multi) | `fp32`    | `s3://tensorized/Salesforce/codegen-350M-multi/model.tensors` |
-| [Salesforce/codegen-350M-multi](https://huggingface.co/Salesforce/codegen-350M-multi) | `fp16`    | `s3://tensorized/Salesforce/codegen-350M-multi/fp16/model.tensors` |
-| [Salesforce/codegen-2B-multi](https://huggingface.co/Salesforce/codegen-2B-multi) | `fp32`    | `s3://tensorized/Salesforce/codegen-2B-multi/model.tensors` |
-| [Salesforce/codegen-2B-multi](https://huggingface.co/Salesforce/codegen-2B-multi) | `fp16`    | `s3://tensorized/Salesforce/codegen-2B-multi/fp16/model.tensors` |
-| [Salesforce/codgen-6B-mono](https://huggingface.co/Salesforce/codgen-6B-mono) | `fp32`    | `s3://tensorized/Salesforce/codgen-6B-mono/model.tensors` |
-| [Salesforce/codgen-6B-mono](https://huggingface.co/Salesforce/codgen-6B-mono) | `fp16`    | `s3://tensorized/Salesforce/codgen-6B-mono/fp16/model.tensors` |
-| [Salesforce/codgen-6B-multi](https://huggingface.co/Salesforce/codgen-6B-multi) | `fp32`    | `s3://tensorized/Salesforce/codgen-6B-multi/model.tensors` |
-| [Salesforce/codgen-6B-multi](https://huggingface.co/Salesforce/codgen-6B-multi) | `fp16`    | `s3://tensorized/Salesforce/codgen-6B-multi/fp16/model.tensors` |
-| [Salesforce/codegen-16B-mono](https://huggingface.co/Salesforce/codegen-16B-mono) | `fp32`    | `s3://tensorized/Salesforce/codegen-16B-mono/model.tensors` |
-| [Salesforce/codegen-16B-mono](https://huggingface.co/Salesforce/codegen-16B-mono) | `fp16`    | `s3://tensorized/Salesforce/codegen-16B-mono/fp16/model.tensors` |
-| [Salesforce/codegen-16B-multi](https://huggingface.co/Salesforce/codegen-16B-multi) | `fp32`    | `s3://tensorized/Salesforce/codegen-16B-multi/model.tensors` |
-| [Salesforce/codegen-16B-multi](https://huggingface.co/Salesforce/codegen-16B-multi) | `fp16`    | `s3://tensorized/Salesforce/codegen-16B-multi/fp16/model.tensors` |
+| [EleutherAI/pythia-12b-deduped](https://huggingface.co/EleutherAI/pythia-12b-deduped)   | `fp32`    | `s3://tensorized/EleutherAI/pythia-12b-deduped/model.tensors`       |
+| [EleutherAI/pythia-12b-deduped](https://huggingface.co/EleutherAI/pythia-12b-deduped)   | `fp16`    | `s3://tensorized/EleutherAI/pythia-12b-deduped/fp16/model.tensors`  |
+| [KoboldAI/fairseq-dense-125M](https://huggingface.co/KoboldAI/fairseq-dense-125M)       | `fp32`    | `s3://tensorized/KoboldAI/fairseq-dense-125M/model.tensors`         |
+| [KoboldAI/fairseq-dense-125M](https://huggingface.co/KoboldAI/fairseq-dense-125M)       | `fp16`    | `s3://tensorized/KoboldAI/fairseq-dense-125M/fp16/model.tensors`    |
+| [KoboldAI/fairseq-dense-355M](https://huggingface.co/KoboldAI/fairseq-dense-355M)       | `fp32`    | `s3://tensorized/KoboldAI/fairseq-dense-355M/model.tensors`         |
+| [KoboldAI/fairseq-dense-355M](https://huggingface.co/KoboldAI/fairseq-dense-355M)       | `fp16`    | `s3://tensorized/KoboldAI/fairseq-dense-355M/fp16/model.tensors`    |
+| [KoboldAI/fairseq-dense-2.7B](https://huggingface.co/KoboldAI/fairseq-dense-2.7B)       | `fp32`    | `s3://tensorized/KoboldAI/fairseq-dense-2.7B/model.tensors`         |
+| [KoboldAI/fairseq-dense-2.7B](https://huggingface.co/KoboldAI/fairseq-dense-2.7B)       | `fp16`    | `s3://tensorized/KoboldAI/fairseq-dense-2.7B/fp16/model.tensors`    |
+| [KoboldAI/fairseq-dense-6.7B](https://huggingface.co/KoboldAI/fairseq-dense-6.7B)       | `fp32`    | `s3://tensorized/KoboldAI/fairseq-dense-6.7B/model.tensors`         |
+| [KoboldAI/fairseq-dense-6.7B](https://huggingface.co/KoboldAI/fairseq-dense-6.7B)       | `fp16`    | `s3://tensorized/KoboldAI/fairseq-dense-6.7B/fp16/model.tensors`    |
+| [KoboldAI/fairseq-dense-13B](https://huggingface.co/KoboldAI/fairseq-dense-13B)         | `fp32`    | `s3://tensorized/KoboldAI/fairseq-dense-13B/model.tensors`          |
+| [KoboldAI/fairseq-dense-13B](https://huggingface.co/KoboldAI/fairseq-dense-13B)         | `fp16`    | `s3://tensorized/KoboldAI/fairseq-dense-13B/fp16/model.tensors`     |
+| [Salesforce/codegen-350M-mono](https://huggingface.co/Salesforce/codegen-350M-mono)     | `fp32`    | `s3://tensorized/Salesforce/codegen-350M-mono/model.tensors`        |
+| [Salesforce/codegen-350M-mono](https://huggingface.co/Salesforce/codegen-350M-mono)     | `fp16`    | `s3://tensorized/Salesforce/codegen-350M-mono/fp16/model.tensors`   |
+| [Salesforce/codegen-350M-multi](https://huggingface.co/Salesforce/codegen-350M-multi)   | `fp32`    | `s3://tensorized/Salesforce/codegen-350M-multi/model.tensors`       |
+| [Salesforce/codegen-350M-multi](https://huggingface.co/Salesforce/codegen-350M-multi)   | `fp16`    | `s3://tensorized/Salesforce/codegen-350M-multi/fp16/model.tensors`  |
+| [Salesforce/codegen-2B-multi](https://huggingface.co/Salesforce/codegen-2B-multi)       | `fp32`    | `s3://tensorized/Salesforce/codegen-2B-multi/model.tensors`         |
+| [Salesforce/codegen-2B-multi](https://huggingface.co/Salesforce/codegen-2B-multi)       | `fp16`    | `s3://tensorized/Salesforce/codegen-2B-multi/fp16/model.tensors`    |
+| [Salesforce/codegen-6B-mono](https://huggingface.co/Salesforce/codegen-6B-mono)         | `fp32`    | `s3://tensorized/Salesforce/codegen-6B-mono/model.tensors`          |
+| [Salesforce/codegen-6B-mono](https://huggingface.co/Salesforce/codegen-6B-mono)         | `fp16`    | `s3://tensorized/Salesforce/codegen-6B-mono/fp16/model.tensors`     |
+| [Salesforce/codegen-6B-multi](https://huggingface.co/Salesforce/codegen-6B-multi)       | `fp32`    | `s3://tensorized/Salesforce/codegen-6B-multi/model.tensors`         |
+| [Salesforce/codegen-6B-multi](https://huggingface.co/Salesforce/codegen-6B-multi)       | `fp16`    | `s3://tensorized/Salesforce/codegen-6B-multi/fp16/model.tensors`    |
+| [Salesforce/codegen-16B-mono](https://huggingface.co/Salesforce/codegen-16B-mono)       | `fp32`    | `s3://tensorized/Salesforce/codegen-16B-mono/model.tensors`         |
+| [Salesforce/codegen-16B-mono](https://huggingface.co/Salesforce/codegen-16B-mono)       | `fp16`    | `s3://tensorized/Salesforce/codegen-16B-mono/fp16/model.tensors`    |
+| [Salesforce/codegen-16B-multi](https://huggingface.co/Salesforce/codegen-16B-multi)     | `fp32`    | `s3://tensorized/Salesforce/codegen-16B-multi/model.tensors`        |
+| [Salesforce/codegen-16B-multi](https://huggingface.co/Salesforce/codegen-16B-multi)     | `fp16`    | `s3://tensorized/Salesforce/codegen-16B-multi/fp16/model.tensors`   |
 
 ## S3 Usage Notes
 `tensorizer` uses the `boto3` library to interact with S3. The easiest way
@@ -321,7 +321,7 @@ in S3. If you update an object in S3, you will need to wait for the cache to
 expire before you can download the updated object. This takes 24 hours since
 the last download.
 
-For this reason, it is recommended to use an unique S3 key for each version
+For this reason, it is recommended to use a unique S3 key for each version
 of a model if you use the `accel-object.ord1.coreweave.com` endpoint.
 
 ## Additional Features

--- a/examples/deserialize.py
+++ b/examples/deserialize.py
@@ -1,12 +1,7 @@
 import torch
-import os
 import time
 from tensorizer import TensorDeserializer
 from tensorizer.utils import no_init_or_tensor, convert_bytes, get_mem_usage
-from collections import OrderedDict
-
-# disable missing keys and unexpected key warnings
-os.environ["TRANSFORMERS_VERBOSITY"] = "error"
 
 from transformers import AutoModelForCausalLM, AutoTokenizer, AutoConfig
 
@@ -21,11 +16,8 @@ s3_uri = f"s3://{s3_bucket}/{model_name}.tensors"
 config = AutoConfig.from_pretrained(model_ref)
 
 # This ensures that the model is not initialized.
-model = no_init_or_tensor(
-    lambda: AutoModelForCausalLM.from_pretrained(
-        None, config=config, state_dict=OrderedDict()
-    )
-)
+with no_init_or_tensor():
+    model = AutoModelForCausalLM.from_config(config)
 
 before_mem = get_mem_usage()
 
@@ -41,18 +33,21 @@ duration = end - start
 per_second = convert_bytes(deserializer.total_tensor_bytes / duration)
 after_mem = get_mem_usage()
 deserializer.close()
-print(f"Deserialized {total_bytes_str} in {end - start:0.2f}s, {per_second}")
+print(f"Deserialized {total_bytes_str} in {end - start:0.2f}s, {per_second}/s")
 print(f"Memory usage before: {before_mem}")
 print(f"Memory usage after: {after_mem}")
 
 # Tokenize and generate
 model.eval()
 tokenizer = AutoTokenizer.from_pretrained(model_ref)
+eos = tokenizer.eos_token_id
 input_ids = tokenizer.encode(
     "¡Hola! Encantado de conocerte. hoy voy a", return_tensors="pt"
 ).to("cuda")
 
 with torch.no_grad():
-    output = model.generate(input_ids, max_new_tokens=50, do_sample=True)
+    output = model.generate(
+        input_ids, max_new_tokens=50, do_sample=True, pad_token_id=eos
+    )
 
 print(f"Output: {tokenizer.decode(output[0], skip_special_tokens=True)}")

--- a/examples/deserialize.py
+++ b/examples/deserialize.py
@@ -12,7 +12,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer, AutoConfig
 
 model_ref = "EleutherAI/gpt-j-6B"
 # To run this at home, swap this with the line below for a smaller example:
-# model_ref = "EleutherAI/gpt-neo-125m"
+# model_ref = "EleutherAI/gpt-neo-125M"
 model_name = model_ref.split("/")[-1]
 # Change this to your S3 bucket.
 s3_bucket = "bucket"

--- a/examples/deserialize.py
+++ b/examples/deserialize.py
@@ -1,5 +1,5 @@
-import torch
 import time
+import torch
 from tensorizer import TensorDeserializer
 from tensorizer.utils import no_init_or_tensor, convert_bytes, get_mem_usage
 

--- a/examples/hf_serialization.py
+++ b/examples/hf_serialization.py
@@ -1,8 +1,8 @@
 import argparse
 import json
 import os
-from collections import OrderedDict
-from typing import Optional, Union
+import gc
+from typing import Optional, Union, Type
 
 import tensorizer.utils as utils
 from tensorizer import TensorSerializer, TensorDeserializer
@@ -12,26 +12,24 @@ import time
 import torch
 import tempfile
 
-os.environ[
-    "TRANSFORMERS_VERBOSITY"
-] = "error"  # disable missing keys and unexpected key warnings
-
 from transformers import (
     AutoConfig,
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    PretrainedConfig,
+    PreTrainedModel,
     CLIPTextModel,
-    CLIPTokenizer,
     CLIPTextConfig,
 )
-from transformers.modeling_utils import PreTrainedModel
 
 from diffusers import (
     AutoencoderKL,
     UNet2DConditionModel,
     StableDiffusionPipeline,
     LMSDiscreteScheduler,
+    ModelMixin,
+    ConfigMixin,
 )
-from diffusers.models.modeling_utils import ModelMixin
-from diffusers.configuration_utils import ConfigMixin
 
 # Setup logger
 logger = logging.getLogger(__name__)
@@ -62,7 +60,7 @@ def serialize_model(
             models do not require this.
         model_directory: The directory to save the serialized model to.
         model_prefix: The prefix to use for the serialized model files. This
-            is purely optional and it allows for multiple models to be
+            is purely optional, and it allows for multiple models to be
             serialized to the same directory. A good example are Stable
             Diffusion models. Default is "model".
     """
@@ -76,9 +74,8 @@ def serialize_model(
         if hasattr(config, "to_json_file"):
             config.to_json_file(f"{dir_prefix}-config.json")
         if isinstance(config, dict):
-            open(f"{dir_prefix}-config.json", "w").write(
-                json.dumps(config, indent=2)
-            )
+            with open(f"{dir_prefix}-config.json", "w") as config_file:
+                config_file.write(json.dumps(config, indent=2))
 
     ts = TensorSerializer(f"{dir_prefix}.tensors")
     ts.write_module(model)
@@ -87,22 +84,27 @@ def serialize_model(
 
 def load_model(
     path_uri: str,
-    modelclass: Union[PreTrainedModel, ModelMixin, ConfigMixin] = None,
-    configclass: Optional[Union[ConfigMixin, AutoConfig]] = None,
-    model_prefix: str = "model",
+    model_class: Union[
+        Type[PreTrainedModel], Type[ModelMixin], Type[ConfigMixin]
+    ],
+    config_class: Optional[
+        Union[Type[PretrainedConfig], Type[ConfigMixin], Type[AutoConfig]]
+    ] = None,
+    model_prefix: Optional[str] = "model",
     device: torch.device = utils.get_device(),
-    dtype: str = None,
+    dtype: Optional[str] = None,
 ) -> torch.nn.Module:
     """
     Given a path prefix, load the model with a custom extension
 
     Args:
         path_uri: path to the model. Can be a local path or a URI
-        modelclass: The model class to load the tensors into.
-        configclass: The config class to load the model config into. This must be
+        model_class: The model class to load the tensors into.
+        config_class: The config class to load the model config into. This must be
             set if you are loading a model from HuggingFace Transformers.
         model_prefix: The prefix to use to distinguish between multiple serialized
             models. The default is "model".
+        device: The device onto which to load the model.
         dtype: The dtype to load the tensors into. If None, the dtype is inferred from
             the model.
     """
@@ -123,21 +125,21 @@ def load_model(
         tensor_stream, device=device, dtype=dtype, lazy_load=True
     )
 
-    if configclass is not None:
+    if config_class is not None:
         try:
-            with tempfile.TemporaryDirectory() as dir:
-                open(os.path.join(dir, "config.json"), "w").write(
-                    stream_io.open_stream(config_uri).read().decode("utf-8")
-                )
-                config = configclass.from_pretrained(dir)
+            with tempfile.TemporaryDirectory() as temp_dir:
+                temp_config_path = os.path.join(temp_dir, "config.json")
+                with open(temp_config_path, "wb") as temp_config:
+                    temp_config.write(stream_io.open_stream(config_uri).read())
+                config = config_class.from_pretrained(temp_dir)
                 config.gradient_checkpointing = True
         except ValueError:
-            config = configclass.from_pretrained(config_uri)
-        model = utils.no_init_or_tensor(
-            lambda: modelclass.from_pretrained(
-                None, config=config, state_dict=OrderedDict()
-            )
-        )
+            config = config_class.from_pretrained(config_uri)
+        with utils.no_init_or_tensor():
+            # AutoModels instantiate from a config via their from_config()
+            # method, while other classes can usually be instantiated directly.
+            config_loader = getattr(model_class, "from_config", model_class)
+            model = config_loader(config)
     else:
         try:
             config = json.loads(
@@ -146,7 +148,8 @@ def load_model(
         except ValueError:
             with open(config_uri, "r") as f:
                 config = json.load(f)
-        model = utils.no_init_or_tensor(lambda: modelclass(**config))
+        with utils.no_init_or_tensor():
+            model = model_class(**config)
 
     tensor_deserializer.load_into_module(model)
 
@@ -157,7 +160,7 @@ def load_model(
     tensors_sz = utils.convert_bytes(tensor_deserializer.total_bytes_read)
     logger.info(
         f"Model tensors loaded in {tensor_load_s:0.2f}s, read "
-        + f"{tensors_sz} @ {rate_str}/s, {utils.get_mem_usage()}"
+        f"{tensors_sz} @ {rate_str}/s, {utils.get_mem_usage()}"
     )
 
     return model
@@ -191,11 +194,15 @@ def df_main(args: argparse.Namespace) -> None:
     pipeline.scheduler.save_pretrained(output_prefix)
 
     if args.validate:
+        del pipeline
+        gc.collect()
         device = utils.get_device()
 
         logger.info("Validating serialization")
         vae = load_model(output_prefix, AutoencoderKL, None, "vae", device)
-        unet = load_model(output_prefix, UNet2DConditionModel, None, "unet")
+        unet = load_model(
+            output_prefix, UNet2DConditionModel, None, "unet", device
+        )
         encoder = load_model(
             output_prefix, CLIPTextModel, CLIPTextConfig, "encoder", device
         )
@@ -204,7 +211,7 @@ def df_main(args: argparse.Namespace) -> None:
             text_encoder=encoder,
             vae=vae,
             unet=unet,
-            tokenizer=CLIPTokenizer.from_pretrained(
+            tokenizer=AutoTokenizer.from_pretrained(
                 args.input_directory, subfolder="tokenizer"
             ),
             scheduler=LMSDiscreteScheduler.from_pretrained(
@@ -212,22 +219,18 @@ def df_main(args: argparse.Namespace) -> None:
             ),
             safety_checker=None,
             feature_extractor=None,
+            requires_safety_checker=False,
         ).to(device)
 
         prompt = "a photo of an astronaut riding a horse on mars"
-        with torch.autocast(
-            "cuda" if torch.cuda.is_available() else "cpu"
-        ):  # for some reason device_type needs to be a string
-            # instead of an actual device
-            pipeline(prompt).images[0].save('test.png')
+        with torch.autocast(device.type):
+            pipeline(prompt).images[0].save("test.png")
 
 
 def hf_main(args):
     output_prefix = args.output_prefix
     print("MODEL PATH:", args.input_directory)
     print("OUTPUT PREFIX:", output_prefix)
-
-    from transformers import AutoModelForCausalLM, AutoConfig, AutoTokenizer
 
     model_config = AutoConfig.from_pretrained(args.input_directory)
     model = AutoModelForCausalLM.from_pretrained(
@@ -243,11 +246,12 @@ def hf_main(args):
 
     serialize_model(model, model_config, output_prefix)
 
-    tokenizer = AutoTokenizer.from_pretrained(
-        args.input_directory
-    ).save_pretrained(output_prefix)
+    tokenizer = AutoTokenizer.from_pretrained(args.input_directory)
+    tokenizer.save_pretrained(output_prefix)
 
     if args.validate:
+        del model, model_config
+        gc.collect()
         device = utils.get_device()
         logger.info("Validating serialization")
         model = load_model(
@@ -259,16 +263,17 @@ def hf_main(args):
             "float16",
         ).eval()
         # test generation
-        tokenizer = AutoTokenizer.from_pretrained(args.input_directory)
+        eos = tokenizer.eos_token_id
         input_ids = tokenizer.encode(
             "¡Hola! Encantado de conocerte. hoy voy a", return_tensors="pt"
         ).to(device)
         with torch.no_grad():
             output = model.generate(
-                input_ids, max_new_tokens=50, do_sample=True
+                input_ids, max_new_tokens=50, do_sample=True, pad_token_id=eos
             )
         logger.info(
-            f"Test Output: {tokenizer.decode(output[0], skip_special_tokens=True)}"
+            "Test Output:"
+            f" {tokenizer.decode(output[0], skip_special_tokens=True)}"
         )
 
 
@@ -276,7 +281,10 @@ def main():
     # usage: hf_serialization.py [-h] --model_type {transformers,diffusers} [--validate] input_directory output_prefix
 
     parser = argparse.ArgumentParser(
-        description="An example script that uses Tensorizer to serialize an HF model to an output directory."
+        description=(
+            "An example script that uses Tensorizer to serialize"
+            "a HuggingFace model to an output directory."
+        )
     )
     parser.add_argument(
         "input_directory",

--- a/examples/hf_serialization.py
+++ b/examples/hf_serialization.py
@@ -1,35 +1,32 @@
 import argparse
-import json
-import os
 import gc
-from typing import Optional, Union, Type
-
-import tensorizer.utils as utils
-from tensorizer import TensorSerializer, TensorDeserializer
-import tensorizer.stream_io as stream_io
+import json
 import logging
-import time
-import torch
+import os
 import tempfile
+import time
+from typing import Optional, Type, Union
 
+import torch
+from diffusers import (
+    AutoencoderKL,
+    ConfigMixin,
+    LMSDiscreteScheduler,
+    ModelMixin,
+    StableDiffusionPipeline,
+    UNet2DConditionModel,
+)
 from transformers import (
     AutoConfig,
     AutoModelForCausalLM,
     AutoTokenizer,
+    CLIPTextConfig,
+    CLIPTextModel,
     PretrainedConfig,
     PreTrainedModel,
-    CLIPTextModel,
-    CLIPTextConfig,
 )
 
-from diffusers import (
-    AutoencoderKL,
-    UNet2DConditionModel,
-    StableDiffusionPipeline,
-    LMSDiscreteScheduler,
-    ModelMixin,
-    ConfigMixin,
-)
+from tensorizer import TensorDeserializer, TensorSerializer, stream_io, utils
 
 # Setup logger
 logger = logging.getLogger(__name__)

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,3 +1,4 @@
 transformers~=4.27.1
 diffusers==0.14.0
+scipy~=1.10.0
 accelerate==0.17.1

--- a/examples/serialize.py
+++ b/examples/serialize.py
@@ -4,7 +4,7 @@ import torch
 
 model_ref = "EleutherAI/gpt-j-6B"
 # For less intensive requirements, swap above with the line below:
-# model_ref = "EleutherAI/gpt-neo-125m"
+# model_ref = "EleutherAI/gpt-neo-125M"
 model_name = model_ref.split("/")[-1]
 # Change this to your S3 bucket.
 s3_bucket = "bucket"

--- a/examples/serialize.py
+++ b/examples/serialize.py
@@ -1,6 +1,6 @@
-from transformers import AutoModelForCausalLM
-from tensorizer import TensorSerializer
 import torch
+from tensorizer import TensorSerializer
+from transformers import AutoModelForCausalLM
 
 model_ref = "EleutherAI/gpt-j-6B"
 # For less intensive requirements, swap above with the line below:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,28 @@ packages = ["tensorizer"]
 
 [tool.setuptools.package-data]
 tensorizer = ["tensors.proto"]
+
+[tool.black]
+line-length = 80
+target-version = ["py38", "py39", "py310", "py311"]
+preview = true
+force-exclude = '''
+(
+  ^/ATTIC
+  | ^/tensors
+  | .*_pb2.py
+)
+'''
+
+[tool.isort]
+profile = "black"
+line_length = 80
+src_paths = ["tensorizer/", "tests/", "examples/"]
+extend_skip_glob = [
+    "ATTIC/*",
+    "*_pb2.py",
+    "tensors/*",
+    "examples/serialize.py",
+    "examples/deserialize.py"
+]
+use_parentheses = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorizer"
-version = "1.0.1"
+version = "1.1.0"
 license = { text = "MIT License" }
 keywords = ["tensorizer", "machine learning", "serialization", "tensor", "pytorch"]
 authors = [

--- a/tensorizer/_wide_pipes.py
+++ b/tensorizer/_wide_pipes.py
@@ -1,9 +1,9 @@
 import contextlib
 import functools
 import logging
-import threading
 import subprocess
 import sys
+import threading
 
 # =============================================================================
 # From `pipe(7)` manpage:

--- a/tensorizer/protobuf.py
+++ b/tensorizer/protobuf.py
@@ -1,10 +1,14 @@
+from collections import OrderedDict
+from typing import BinaryIO
+from typing import OrderedDict as OrderedDictType
+from typing import Tuple, Union
+
+import numpy as np
 import torch
 from torch import Tensor
-import numpy as np
-import tensors.tensors_pb2 as tensors_pb
-from tensors.tensors_pb2 import Tensor as TensorPb
-from typing import OrderedDict as OrderedDictType, Tuple, Union, BinaryIO
-from collections import OrderedDict
+
+import tensorizer.tensors_pb2 as tensors_pb
+from tensorizer.tensors_pb2 import Tensor as TensorPb
 
 DtypePbs = {
     torch.float32: tensors_pb.DT_FLOAT32,
@@ -84,7 +88,7 @@ def serialize_tensor(
         dtype=DtypePbs[t.dtype],
         shape=t.shape,
         data=t.cpu().detach().numpy().tobytes(),
-        **extra_opts
+        **extra_opts,
     )
 
 

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -11,23 +11,25 @@ except ImportError:
     fcntl = None
     resource = None
 
-from enum import Enum
 import collections.abc
+import ctypes
+import hashlib
 import io
+import logging
+import mmap
 import os
+import struct
+import tempfile
+import time
+import typing
+import zlib
+from enum import Enum
+
+import numpy
+import torch
+
 import tensorizer.stream_io as stream_io
 import tensorizer.utils as utils
-import mmap
-import numpy
-import struct
-import time
-import torch
-import typing
-import logging
-import tempfile
-import hashlib
-import zlib
-import ctypes
 
 if torch.cuda.is_available():
     cudart = torch.cuda.cudart()
@@ -35,7 +37,7 @@ else:
     cudart = None
 
 from collections import OrderedDict
-from typing import Optional, Tuple, Union, List, Iterator, Dict, Callable, Any
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 lz4 = None
 
@@ -100,8 +102,8 @@ def _convert_dtype_to_numpy(dtype: Union[numpy.dtype, str, torch.dtype]):
 
         if numpy_dtype is None:
             raise TypeError(
-                "The provided torch.dtype class could not"
-                " be converted to a numpy.dtype"
+                "The provided torch.dtype class could not be converted to a"
+                " numpy.dtype"
             )
         else:
             # Convert it from a dtype class to a dtype object instance
@@ -184,7 +186,7 @@ class TensorDeserializer(collections.abc.Mapping):
             str,
             bytes,
             os.PathLike,
-            int
+            int,
         ],
         device: Union[torch.device, str, None] = None,
         filter_func: Optional[Callable[[str], Union[bool, Any]]] = None,
@@ -452,7 +454,7 @@ class TensorDeserializer(collections.abc.Mapping):
                 self._cache[self._prior_key] = False
             if self._cache[name] is False:
                 raise RuntimeError(
-                    f"Tensor {name} already overwritten in " "plaid_mode"
+                    f"Tensor {name} already overwritten in plaid_mode"
                 )
             self._prior_key = name
 

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -2,17 +2,17 @@ import functools
 import io
 import logging
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
 import typing
 import weakref
+from io import SEEK_CUR, SEEK_END, SEEK_SET
+from typing import Any, Dict, Optional, Tuple, Union
 from urllib.parse import urlparse
 
 import boto3
-from io import SEEK_SET, SEEK_CUR, SEEK_END
-from typing import Union, Optional, Dict, Any, Tuple
-import shutil
 
 import tensorizer._wide_pipes as _wide_pipes
 
@@ -185,7 +185,7 @@ class CURLStreamFile:
         self._error_context.append(msg)
 
     def _reproduce_and_capture_error(
-            self, expect_code: Optional[int]
+        self, expect_code: Optional[int]
     ) -> Optional[str]:
         """
         Re-attempts the connection with stderr attached to a pipe
@@ -211,7 +211,7 @@ class CURLStreamFile:
             "-f",  # Don't return HTML/XML error webpages
             "-s",  # Silence most output
             "-S",  # Keep error messages
-            self._uri
+            self._uri,
         ]
         try:
             result = subprocess.run(
@@ -220,7 +220,7 @@ class CURLStreamFile:
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.PIPE,
                 text=True,
-                timeout=3
+                timeout=3,
             )
 
         except subprocess.TimeoutExpired:
@@ -238,8 +238,10 @@ class CURLStreamFile:
         if return_code:
             error = self._reproduce_and_capture_error(expect_code=return_code)
             if error is None:
-                error = f"curl error: ({return_code}), see" \
-                        f" https://curl.se/docs/manpage.html#{return_code}"
+                error = (
+                    f"curl error: ({return_code}), see"
+                    f" https://curl.se/docs/manpage.html#{return_code}"
+                )
         else:
             error = ""
 
@@ -470,7 +472,8 @@ def _infer_credentials(
     # Try to find default credentials if at least one is not specified
     if s3_config_path is not None and not os.path.exists(s3_config_path):
         raise FileNotFoundError(
-            f"Explicitly specified s3_config_path does not exist: {s3_config_path}"
+            "Explicitly specified s3_config_path does not exist:"
+            f" {s3_config_path}"
         )
     try:
         parsed: _ParsedCredentials = _get_s3cfg_values(s3_config_path)

--- a/tensorizer/utils.py
+++ b/tensorizer/utils.py
@@ -1,4 +1,15 @@
 import torch
+import contextlib
+import contextvars
+import threading
+from typing import (
+    Optional,
+    Callable,
+    Union,
+    TypeVar,
+    ContextManager,
+    NamedTuple,
+)
 
 try:
     import resource
@@ -20,6 +31,10 @@ except ImportError:
 __all__ = [
     "convert_bytes",
     "get_device",
+    "GlobalGPUMemoryUsage",
+    "TorchGPUMemoryUsage",
+    "CPUMemoryUsage",
+    "MemoryUsage",
     "get_mem_usage",
     "get_gpu_name",
     "no_init_or_tensor",
@@ -27,114 +42,347 @@ __all__ = [
 
 
 # Silly function to convert to human bytes
-def convert_bytes(num):
+def convert_bytes(num, decimal=True) -> str:
     """
-    this function will convert bytes to MB.... GB... etc
-    """
-    step_unit = 1000.0
+    Convert bytes to MB, GB, etc.
 
-    for x in ["bytes", "KB", "MB", "GB", "TB"]:
+    Args:
+        num: Quantity of bytes to format.
+        decimal: Whether to use decimal or binary units
+            (e.g. KB = 1000 bytes vs. KiB = 1024 bytes).
+
+    Returns:
+        A string in the format ``<n> <units>`` (e.g. ``123.4 MB``).
+    """
+    if decimal:
+        step_unit = 1000.0
+        units = ("bytes", "KB", "MB", "GB", "TB", "PB")
+    else:
+        step_unit = 1024.0
+        units = ("bytes", "KiB", "MiB", "GiB", "TiB", "PiB")
+
+    for unit in units[:-1]:
         if num < step_unit:
-            return "%3.1f %s" % (num, x)
+            break
         num /= step_unit
+    else:
+        unit = units[-1]
+    return "%3.1f %s" % (num, unit)
 
 
 def get_device() -> torch.device:
     return torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 
-def _get_gpu_mem_usage():
+class GlobalGPUMemoryUsage(NamedTuple):
+    """Total memory usage statistics across all processes for a single GPU."""
+
+    total: int
+    free: int
+    used: int
+
+    @classmethod
+    def now(cls, device=None) -> Optional["GlobalGPUMemoryUsage"]:
+        """
+        Capture a snapshot of the current total memory usage on a single GPU.
+
+        Args:
+            device: The GPU to gather memory statistics for.
+                If None, the current GPU is used,
+                as determined by ``torch.cuda.current_device()``.
+
+        Returns:
+            A tuple of (`total`, `free`, `used`) VRAM in bytes, if possible.
+
+            None if neither PyTorch >=1.10 nor pynvml is available.
+        """
+        if not torch.cuda.is_available():
+            return None
+
+        # torch.cuda.mem_get_info() was introduced in PyTorch 1.10
+        mem_get_info = getattr(torch.cuda, "mem_get_info", None)
+        if mem_get_info is not None:
+            free, total = mem_get_info(device)
+            return cls(total, free, total - free)
+        elif pynvml is not None:
+            # Normalize the device to an int
+            if isinstance(device, (int, str, bytes)):
+                device = torch.device(device)
+            if isinstance(device, torch.device):
+                if device.type == "cpu":
+                    return None
+                else:
+                    device = device.index
+            if device is None:
+                device = torch.cuda.current_device()
+            nvml_device = pynvml.nvmlDeviceGetHandleByIndex(device)
+            gpu_info = pynvml.nvmlDeviceGetMemoryInfo(nvml_device)
+            return cls(gpu_info.total, gpu_info.free, gpu_info.used)
+        else:
+            return None
+
+    def __str__(self):
+        return "GPU: (U: {:,}MiB F: {:,}MiB T: {:,}MiB)".format(
+            self.used >> 20, self.free >> 20, self.total >> 20
+        )
+
+
+class TorchGPUMemoryUsage(NamedTuple):
+    """Memory usage statistics for PyTorch on a single GPU."""
+
+    reserved: int
+    reserved_max: int
+    used: int
+    used_max: int
+
+    @classmethod
+    def now(cls, device=None) -> Optional["TorchGPUMemoryUsage"]:
+        """
+        Capture a snapshot of the current total memory usage on a single GPU.
+
+        Args:
+            device: The GPU to gather memory statistics for.
+                If None, the current GPU is used,
+                as determined by ``torch.cuda.current_device()``.
+
+        Returns:
+            A tuple of (`reserved`, `reserved_max`, `used`, `used_max`)
+            memory statistics for PyTorch in bytes, if possible.
+
+            None if CUDA isn't available.
+        """
+        if torch.cuda.is_available():
+            stats = torch.cuda.memory.memory_stats(device)
+            return cls(
+                stats.get("reserved_bytes.all.current", 0),
+                stats.get("reserved_bytes.all.peak", 0),
+                stats.get("allocated_bytes.all.current", 0),
+                stats.get("allocated_bytes.all.peak", 0),
+            )
+        else:
+            return None
+
+    def __str__(self):
+        return "TORCH: (R: {:,}MiB/{:,}MiB, A: {:,}MiB/{:,}MiB)".format(
+            self.reserved >> 20,
+            self.reserved_max >> 20,
+            self.used >> 20,
+            self.used_max >> 20,
+        )
+
+
+class CPUMemoryUsage(NamedTuple):
+    """Memory usage statistics for CPU RAM."""
+
+    maxrss: int
+    free: int
+
+    @classmethod
+    def now(cls) -> "CPUMemoryUsage":
+        """
+        Capture a snapshot of the current CPU RAM usage.
+
+        Returns:
+            A tuple of (`maxrss`, `free`) RAM statistics in bytes,
+            where maxrss is the max resident set size of the current process.
+
+            On Unix, the system call ``getrusage(2)`` is used
+            to measure the maxrss, so the granularity is 1024 bytes,
+            but the unit is still bytes.
+        """
+        if resource is not None:
+            maxrss = (
+                resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+                + resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
+            ) << 10
+        else:
+            process = psutil.Process()
+            maxrss = process.memory_info().rss + sum(
+                p.memory_info().rss for p in process.children(True)
+            )
+        vmem = psutil.virtual_memory()
+        return cls(maxrss, vmem.free)
+
+    def __str__(self):
+        return "CPU: (maxrss: {:,}MiB F: {:,}MiB)".format(
+            self.maxrss >> 20, self.free >> 20
+        )
+
+
+class MemoryUsage(NamedTuple):
     """
-    Returns a tuple of (total_vram, free_vram, used_vram) in bytes if possible.
-    Returns None if neither PyTorch >=1.10 nor pynvml is available.
+    Combined statistics for CPU, total GPU, and PyTorch memory usage.
+
+    Gathers `CPUMemoryUsage`, `GlobalGPUMemoryUsage`, and `TorchGPUMemoryUsage`
+    together in one tuple.
     """
-    if not torch.cuda.is_available():
-        return None
-    mem_get_info = getattr(torch.cuda, "mem_get_info", None)
-    if mem_get_info is not None:
-        free, total = mem_get_info()
-        return total, free, total - free
-    elif pynvml is not None:
-        cudadev = torch.cuda.current_device()
-        nvml_device = pynvml.nvmlDeviceGetHandleByIndex(cudadev)
-        gpu_info = pynvml.nvmlDeviceGetMemoryInfo(nvml_device)
-        return gpu_info.total, gpu_info.free, gpu_info.used
-    else:
-        return None
+
+    cpu: CPUMemoryUsage
+    gpu: Optional[GlobalGPUMemoryUsage]
+    torch: Optional[TorchGPUMemoryUsage]
+
+    @classmethod
+    def now(cls, device=None):
+        """
+        Capture a snapshot of CPU, total GPU, and PyTorch memory usage.
+        If GPU memory usage statistics are not available,
+        the `gpu` and `torch` fields of the resulting tuple are None.
+
+        Args:
+            device: The GPU to gather both total and PyTorch-specific
+                memory statistics for. If None, the current GPU is used,
+                as determined by ``torch.cuda.current_device()``.
+
+        Returns:
+            A tuple of (`cpu`, `gpu`, `torch`) memory statistics.
+            If GPU memory usage statistics are not available,
+            the `gpu` and `torch` fields are None.
+
+            See the respective classes, `CPUMemoryUsage`,
+            `GlobalGPUMemoryUsage`, and `TorchGPUMemoryUsage`,
+            for more information on each component.
+        """
+        gpu_info = torch_info = None
+        try:
+            gpu_info = GlobalGPUMemoryUsage.now(device)
+            torch_info = TorchGPUMemoryUsage.now(device)
+        except AssertionError:
+            pass
+        return cls(CPUMemoryUsage.now(), gpu_info, torch_info)
+
+    def __str__(self):
+        return " ".join(str(item) for item in self if item)
 
 
 def get_mem_usage() -> str:
     """
-    Returns memory usage statistics for the CPU, GPU, and Torch.
+    Captures and formats memory usage statistics for the CPU, GPU, and PyTorch.
 
-    :return:
+    Equivalent to ``str(MemoryUsage.now())``.
+
+    Returns:
+        A formatted string summarizing memory usage
+        across the CPU, GPU, and PyTorch.
     """
-    gpu_str = ""
-    torch_str = ""
-    try:
-        gpu_info = _get_gpu_mem_usage()
-        if gpu_info is not None:
-            gpu_total, gpu_free, gpu_used = gpu_info
-            gpu_total >>= 20
-            gpu_free >>= 20
-            gpu_used >>= 20
-            gpu_str = f"GPU: (U: {gpu_used:,}MiB F: {gpu_free:,}MiB T: {gpu_total:,}MiB) "
-        torch_reserved_gpu = torch.cuda.memory.memory_reserved() >> 20
-        torch_reserved_max = torch.cuda.memory.max_memory_reserved() >> 20
-        torch_used_gpu = torch.cuda.memory_allocated() >> 20
-        torch_max_used_gpu = torch.cuda.max_memory_allocated() >> 20
-        torch_str = (
-            f"TORCH: (R: {torch_reserved_gpu:,}MiB/"
-            f"{torch_reserved_max:,}MiB, "
-            f"A: {torch_used_gpu:,}MiB/{torch_max_used_gpu:,}MiB)"
-        )
-    except AssertionError:
-        pass
-    if resource is not None:
-        cpu_maxrss = (
-            resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
-            + resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
-        ) >> 10
-    else:
-        process = psutil.Process()
-        cpu_maxrss = (
-            process.memory_info().rss
-            + sum(p.memory_info().rss for p in process.children(True))
-        ) >> 20
-    cpu_vmem = psutil.virtual_memory()
-    cpu_free = cpu_vmem.free >> 20
-    return (
-        f"CPU: (maxrss: {cpu_maxrss:,}MiB F: {cpu_free:,}MiB) "
-        f"{gpu_str}{torch_str}"
-    )
+    return str(MemoryUsage.now())
 
 
 def get_gpu_name() -> str:
     if torch.cuda.is_available():
-        return torch.cuda.get_device_name(0)
+        return torch.cuda.get_device_name()
     return "N/A"
 
 
-def no_init_or_tensor(loading_code):
-    def dummy(self):
-        return
+Model = TypeVar("Model")
 
-    modules = [torch.nn.Linear, torch.nn.Embedding, torch.nn.LayerNorm]
-    original = {}
-    for mod in modules:
-        original[mod] = mod.reset_parameters
-        mod.reset_parameters = dummy
-    original_empty = torch.empty
 
-    # when torch.empty is called, make it map to meta device by replacing the
-    # device in kwargs.
-    torch.empty = lambda *args, **kwargs: original_empty(
-        *args, **{**kwargs, "device": "meta"}
+def no_init_or_tensor(
+    loading_code: Optional[Callable[..., Model]] = None
+) -> Union[Model, ContextManager]:
+    """
+    Suppress the initialization of weights while loading a model.
+
+    Can either directly be passed a callable containing model-loading code,
+    which will be evaluated with weight initialization suppressed,
+    or used as a context manager around arbitrary model-loading code.
+
+    Args:
+        loading_code: Either a callable to evaluate
+            with model weight initialization suppressed,
+            or None (the default) to use as a context manager.
+
+    Returns:
+        The return value of `loading_code`, if `loading_code` is callable.
+
+        Otherwise, if `loading_code` is None, returns a context manager
+        to be used in a `with`-statement.
+
+    Example:
+        As a context manager::
+
+            from transformers import AutoConfig, AutoModelForCausalLM
+            config = AutoConfig("EleutherAI/gpt-j-6B")
+            with no_init_or_tensor():
+                model = AutoModelForCausalLM.from_config(config)
+
+        Or, directly passing a callable::
+
+            from transformers import AutoConfig, AutoModelForCausalLM
+            config = AutoConfig("EleutherAI/gpt-j-6B")
+            model = no_init_or_tensor(lambda: AutoModelForCausalLM.from_config(config))
+    """
+    if loading_code is None:
+        return _NoInitOrTensorImpl.context_manager()
+    elif callable(loading_code):
+        with _NoInitOrTensorImpl.context_manager():
+            return loading_code()
+    else:
+        raise TypeError(
+            "no_init_or_tensor() expected a callable to evaluate,"
+            " or None if being used as a context manager;"
+            f' got an object of type "{type(loading_code).__name__}" instead.'
+        )
+
+
+class _NoInitOrTensorImpl:
+    # Implementation of the thread-safe, async-safe, re-entrant context manager
+    # version of no_init_or_tensor().
+    # This class essentially acts as a namespace.
+    # It is not instantiable, because modifications to torch functions
+    # inherently affect the global scope, and thus there is no worthwhile data
+    # to store in the class instance scope.
+    _MODULES = (torch.nn.Linear, torch.nn.Embedding, torch.nn.LayerNorm)
+    _MODULE_ORIGINALS = tuple((m, m.reset_parameters) for m in _MODULES)
+    _ORIGINAL_EMPTY = torch.empty
+
+    is_active = contextvars.ContextVar(
+        "_NoInitOrTensorImpl.is_active", default=False
     )
+    _count_active: int = 0
+    _count_active_lock = threading.Lock()
 
-    result = loading_code()
-    for mod in modules:
-        mod.reset_parameters = original[mod]
-    torch.empty = original_empty
+    @classmethod
+    @contextlib.contextmanager
+    def context_manager(cls):
+        if cls.is_active.get():
+            yield
+            return
 
-    return result
+        with cls._count_active_lock:
+            cls._count_active += 1
+            if cls._count_active == 1:
+                for mod in cls._MODULES:
+                    mod.reset_parameters = cls._disable(mod.reset_parameters)
+                # When torch.empty is called, make it map to meta device by replacing
+                # the device in kwargs.
+                torch.empty = cls._meta_empty
+        reset_token = cls.is_active.set(True)
+
+        try:
+            yield
+        finally:
+            cls.is_active.reset(reset_token)
+            with cls._count_active_lock:
+                cls._count_active -= 1
+                if cls._count_active == 0:
+                    torch.empty = cls._ORIGINAL_EMPTY
+                    for mod, original in cls._MODULE_ORIGINALS:
+                        mod.reset_parameters = original
+
+    @staticmethod
+    def _disable(func):
+        def wrapper(*args, **kwargs):
+            # Behaves as normal except in an active context
+            if not _NoInitOrTensorImpl.is_active.get():
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    @staticmethod
+    def _meta_empty(*args, **kwargs):
+        # Behaves as torch.empty except in an active context
+        if _NoInitOrTensorImpl.is_active.get():
+            kwargs["device"] = "meta"
+        return _NoInitOrTensorImpl._ORIGINAL_EMPTY(*args, **kwargs)
+
+    __init__ = None

--- a/tensorizer/utils.py
+++ b/tensorizer/utils.py
@@ -297,7 +297,7 @@ def no_init_or_tensor(
         Otherwise, if `loading_code` is None, returns a context manager
         to be used in a `with`-statement.
 
-    Example:
+    Examples:
         As a context manager::
 
             from transformers import AutoConfig, AutoModelForCausalLM

--- a/tensorizer/utils.py
+++ b/tensorizer/utils.py
@@ -1,15 +1,16 @@
-import torch
 import contextlib
 import contextvars
 import threading
 from typing import (
-    Optional,
     Callable,
-    Union,
-    TypeVar,
     ContextManager,
     NamedTuple,
+    Optional,
+    TypeVar,
+    Union,
 )
+
+import torch
 
 try:
     import resource

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,20 +1,20 @@
 import contextlib
 import gc
 import os
+import re
 import tempfile
 import unittest
-import re
 from typing import Tuple
+
 import torch
 
-os.environ[
-    "TOKENIZERS_PARALLELISM"
-] = "false"  # avoids excessive warnings about forking after using a tokenizer
+os.environ["TOKENIZERS_PARALLELISM"] = (
+    "false"  # avoids excessive warnings about forking after using a tokenizer
+)
 
-from transformers import AutoModelForCausalLM, AutoTokenizer, AutoConfig
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 
-from tensorizer import TensorSerializer, TensorDeserializer
-from tensorizer import utils
+from tensorizer import TensorDeserializer, TensorSerializer, utils
 
 model_name = "EleutherAI/gpt-neo-125M"
 num_hellos = 400
@@ -41,13 +41,18 @@ def check_deserialized(deserialized, model_name: str, allow_subset=False):
     if not allow_subset:
         assert orig_sd.keys() == deserialized.keys()
     for k, v in deserialized.items():
+        # fmt: off
         assert k in orig_sd, \
             f"{k} not in {orig_sd.keys()}"
+
         assert v.size() == orig_sd[k].size(), \
             f"{v.size()} != {orig_sd[k].size()}"
+
         assert v.dtype == orig_sd[k].dtype, \
             f"{v.dtype} != {orig_sd[k].dtype}"
+
         assert torch.all(orig_sd[k].to(v.device) == v)
+        # fmt: on
     del orig_sd
     gc.collect()
 
@@ -261,7 +266,8 @@ class TestDeserialization(unittest.TestCase):
             " or matches all tensor names."
             " Update the pattern and/or custom_check"
             " to use more informative filtering criteria."
-            "\n\nTensors present in the model: " + " ".join(all_keys)
+            "\n\nTensors present in the model: "
+            + " ".join(all_keys)
         )
 
         with self.subTest(msg="Testing regex filter_func"):

--- a/tests/test_stream_io.py
+++ b/tests/test_stream_io.py
@@ -1,8 +1,10 @@
 import contextlib
 import os
 import unittest
-import moto
+
 import boto3
+import moto
+
 from tensorizer import stream_io
 
 NEO_URL = (
@@ -78,11 +80,11 @@ def tear_down_moto(old_environment):
 
 @contextlib.contextmanager
 def mock_server():
+    import logging
+
     from moto.server import ThreadedMotoServer
 
     # Disable mock server logs
-    import logging
-
     werkzeug_logger = logging.getLogger("werkzeug")
     old_log_level = werkzeug_logger.getEffectiveLevel()
     werkzeug_logger.setLevel(logging.CRITICAL + 1)


### PR DESCRIPTION
# Better `utils`, Examples, Docs, and Style

No changes here are breaking. New features were added, so there is a minor version bump from 1.0.1 to 1.1.0.

## Updates to `utils` & Examples

TL;DR: Examples now load empty models with less jank, `no_init_or_tensor()` can be used as a context manager, and some other examples were fixed up with respect to missing dependencies and small errors.

- 589e5dfbc46c969a7f56a03b31047d3f569e8429: Turned `no_init_or_tensor()` into a context manager (backwards-compatible), ported finetuner version of `get_mem_usage()` for `utils`, improved `utils` overall.
<details><summary>Expand for full details</summary>
<p>

`get_mem_usage()` now has 4 granular modes for querying CPU RAM usage, total GPU memory usage, and PyTorch GPU memory usage, split out into 3 classes, named `CPUMemoryUsage`, `GlobalGPUMemoryUsage`, and `TorchGPUMemoryUsage`, alongside `MemoryUsage`, which gathers them all together into one class. `get_mem_usage()` is now an alias for `str(MemoryUsage.now())`, for backwards compatibility.

This was ported from [commit #b4cca6c](https://github.com/coreweave/kubernetes-cloud/commit/b4cca6c414d05083bf688152ce982b3de794cb91) in `coreweave/kubernetes-cloud`, but improved. This version supports Windows and older PyTorch versions, and has better documentation.

`no_init_or_tensor()` can now be used as a context manager when called without arguments. Its previous functionality is still available when passed a callable object.
The context manager form of `no_init_or_tensor()` is thread-safe, async-safe, and re-entrant. It relies on context variables to selectively modify implementations of PyTorch functions only where the context manager is active, similar to the Windows implementation of `_wide_pipes.widen_new_pipes()`.

`no_init_or_tensor()` now has a descriptive docstring, including usage examples for both forms. All of the memory classes now have descriptive docstrings. `convert_bytes()` has a slightly more descriptive docstring as well as a mode for using binary prefixes instead of decimal, and a correctness fix for very large values. `utils` is in good shape.

</p>
</details>

- 396c0c1169cb5f53ea5754950f2643caab88fab4: Improved initialization of models in deserialization examples
  - This migrates from `AutoModel.from_pretrained()` to `AutoModel.from_config()`, and the context manager form of `no_init_or_tensor()` over lambdas.

<details><summary>Expand for full details</summary>
<p>

Deserialization examples were previously using:
```py
AutoModelForCausalLM.from_pretrained(
    None, config=config, state_dict=OrderedDict()
)
```
Wrapped in `no_init_or_tensor()` to load a model of the right shape without any of its weights. This isn't ideal, as `from_pretrained()` is designed specifically to load weights, and screams out a wall of warnings if you use it this way.
This has been switched to use `from_config()` instead, which is designed for the use case of creating a model of the right shape without loading any weights. `from_config()` exists for `AutoModel`s, while concrete model types can typically be instantiated directly with a config object.
This switch allows the removal of the `TRANSFORMERS_VERBOSITY` environment variable overrides scattered throughout the examples and tests, and is simpler to understand and harder to get wrong while using the library compared to the previous hacky method with `from_pretrained()`.

The examples of `no_init_or_tensor()` have additionally all been switched over to use its context manager form. The context manager form appears more natural than an artificial lambda when compared with the very similar context manager `no_init_weights()` in `transformers`.

Usages of `model.generate()` now additionally specify `pad_token_id = eos_token_id`. This is already the default behaviour of `transformers`, but specifying it explicitly prevents a warning (which is necessary now that warnings aren't globally suppressed).

Other small type annotation and style fixes are also included for `hf_serialization`, along with a fix for opening a couple files without closing them.

</p>
</details> 

- 931831d125060e320dd5e283d4a15e4df6c5863e: Added `scipy` to `examples/requirements.txt` for the `hf_serialization` example.
  - `scipy` is necessary for its `diffusers` setup using `LMSDiscreteScheduler`.
  - This omission was previously noted in #23.
- 531723a64dbbae9760c0c81bcbedaa47ba4e87b6: Bumped the minor version from 1.0.1 to 1.1.0 corresponding to new `utils` features.

## Documentation Improvements

TL;DR: Docstrings for important functions now include examples and links, and fixed some URI typos for `s3://tensorized` usage.

- 43910dfd3831aa48a6db50270db6cf383dc1fd30: Fixed capitalization for `gpt-neo-125M` in the `README`, as it didn't match the case-sensitive `tensorized` bucket entry.
  - The `README` examples don't directly use `s3://tensorized`, but since it is featured as one of two named models in the main documentation, it's better to have it match for people who want to experiment with the `tensorized` bucket.
- 8361dc522f1eb5e73ecb578fcf64a835595ac4ae: Fixed typos in some of the entries in the `tensorized` models table that made both the HuggingFace links and S3 URIs invalid.
  - The rest of the S3 URIs listed in the table have been double-checked to ensure that they work too. All clear.
- 11cfc23fd9cd3fce16f89c23518814af2f0c9551: Added usage examples, notes, and links to documentation in various important docstrings to make the library easier to use.
  - `TensorSerializer`'s docstring shows a slimmed-down but complete version of the `examples/serialize.py` example, with a note about S3 credential auto-detection and how to configure it manually.
  - `TensorDeserializer`'s docstring shows a complete example of the proper method of deserializing a 16-bit model from `s3://tensorized`, along with a partial example of using credentials with `stream_io.open_stream()` to deserialize a model from a private S3 bucket.
  - (Added in 589e5dfbc46c969a7f56a03b31047d3f569e8429) `stream_io.open_stream()`'s docstring features a note that it can be used directly with `TensorSerializer` and `TensorDeserializer`, as well as 4 examples of opening various types of streams:
    - Writing to S3 with manually-specified credentials,
    - Reading from S3 with auto-detected credentials,
    - Reading from S3 with credentials specified in a custom `.s3cfg` file, and
    - Reading from an `https://` URI.
  - Additionally, all docstrings now consistently use Google's style and reStructuredText formatting (`Args:` over `:param:`).

## Style Improvements

Pre-commit hooks n' formatter configs!

- 47bb899785ce0d2a107bcc7bc55f9fc4a70b0be0 & f3b341727a79e11fac5f4610364bf7f4039953bb: Added configurations to `pyproject.toml` for `black` and `isort`, and defined [pre-commit hooks](https://pre-commit.com/) in `.pre-commit-config.yaml` to run them automatically.
  - Run `pip install pre-commit` and then `pre-commit install` to register them with Git.
  - Run `pre-commit run --all-files` to run them at any time.
  - The `pyproject.toml` configurations mean that `black .` and `isort .` with no other arguments are sufficient to format code with all the correct options for this codebase.