### PR TITLE
fix(stream_io): Raise an error when `curl` is required, but not found

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorizer"
-version = "1.1.0"
+version = "1.1.1"
 license = { text = "MIT License" }
 keywords = ["tensorizer", "machine learning", "serialization", "tensor", "pytorch"]
 authors = [

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -125,7 +125,7 @@ class CURLStreamFile:
         self._error_context = []
 
         if curl_path is None:
-            RuntimeError(
+            raise RuntimeError(
                 "cURL is a required dependency for streaming downloads"
                 " and could not be found."
             )


### PR DESCRIPTION
A `RuntimeError` is created when a `CURLStreamFile` is instantiated but `curl` is not available, but due to a bug, that error hasn't been raised, just created and then discarded. This leads to an extremely cryptic error a short while later when attempting a streaming load without actually having `curl`.

This fixes the logic involved to actually raise the created error, and bumps `tensorizer` to version `1.1.1`.

In code, this changes:
```py
if curl_path is None:
    RuntimeError(
        "cURL is a required dependency for streaming downloads"
        " and could not be found."
    )
```
To:
```py
if curl_path is None:
    raise RuntimeError(
        "cURL is a required dependency for streaming downloads"
        " and could not be found."
    )
```