### PR TITLE
feat: Add support for bfloat16 models

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,18 @@ The `state_dict` can also be used to initialize a HuggingFace Transformers
 AutoModel. But HuggingFace Transformers performs three or more copies of
 the data, so memory use will explode.
 
+### bfloat16 Support
+
+Tensorizer supports models using the `bfloat16` data type. However, tensorizer
+uses numpy to save the tensors as binary and numpy doesn't support `bfloat16`.
+This means that special conversions need to be applied which decreases the
+performance of both serialization and deserialization.
+
+To be saved, the torch tensor is cast to fp32, adding an additional 16 bits.
+This value is converted to numpy, then bit shifted and cast down to a
+`np.uint16` to save the original 16 bits from torch's `bfloat16`. The reverse
+happens during the deserialization process.
+
 ## Running Tests
 `tensorizer` uses `unittest` for testing.
 The tests have their own set of dependencies, which can be installed with

--- a/README.md
+++ b/README.md
@@ -351,17 +351,21 @@ The `state_dict` can also be used to initialize a HuggingFace Transformers
 AutoModel. But HuggingFace Transformers performs three or more copies of
 the data, so memory use will explode.
 
-### bfloat16 Support
+### `bfloat16` Support
 
 Tensorizer supports models using the `bfloat16` data type. However, tensorizer
 uses numpy to save the tensors as binary and numpy doesn't support `bfloat16`.
-This means that special conversions need to be applied which decreases the
-performance of both serialization and deserialization.
+This means that special conversions need to be applied.
 
-To be saved, the torch tensor is cast to fp32, adding an additional 16 bits.
-This value is converted to numpy, then bit shifted and cast down to a
-`np.uint16` to save the original 16 bits from torch's `bfloat16`. The reverse
-happens during the deserialization process.
+To be saved, the torch tensor is cast to `int16` before being converted to
+numpy, which doesn't change any of the underlying data. When serialized, the
+original `blfoat16` datatype string is also saved so that it will be cast back
+to `bfloat16` during the deserialization process.
+
+The `complex32` datatype is supported in a similar way, by casting to `int32`.
+The quantized datatypes (`qint8`, `qint32`, etc.) are not currently supported
+by tensorizer as they would require supplemental quantization parameters to be
+deserialized correctly.
 
 ## Running Tests
 `tensorizer` uses `unittest` for testing.

--- a/README.md
+++ b/README.md
@@ -367,6 +367,33 @@ The quantized datatypes (`qint8`, `qint32`, etc.) are not currently supported
 by tensorizer as they would require supplemental quantization parameters to be
 deserialized correctly.
 
+### Numpy Support
+
+Tensorizer can be used with `numpy` directly to read and write
+`numpy.ndarray`'s.
+
+The serializer's `write_tensor` function handles supplying both
+`torch.Tensor`'s and `numpy.ndarray`'s.
+
+The deserializer has a separate function `read_numpy_arrays` that will return
+the data as `numpy.ndarray`'s.
+
+As explained above in [bfloat16 support](#bfloat16-support), tensorizer uses
+special conversions to write opaque datatypes, those not supported by numpy.
+Therefore, special considerations need to be taken when loading the data as
+`numpy.ndarray`'s.
+
+By default, the `read_numpy_arrays` function sets its `allow_raw_data`
+parameter to `False`. This means that if the data contains opaque datatypes,
+a `ValueError` will be raised.
+
+If you want to return the raw data regardless, set `allow_raw_data` to be
+`True`.
+
+A fifth variable is returned by the `read_numpy_arrays` generator, which is a
+`bool` that indicates whether the returned data was originally an opaque
+datatype.
+
 ## Running Tests
 `tensorizer` uses `unittest` for testing.
 The tests have their own set of dependencies, which can be installed with

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ This means that special conversions need to be applied.
 
 To be saved, the torch tensor is cast to `int16` before being converted to
 numpy, which doesn't change any of the underlying data. When serialized, the
-original `blfoat16` datatype string is also saved so that it will be cast back
+original `bfloat16` datatype string is also saved so that it will be cast back
 to `bfloat16` during the deserialization process.
 
 The `complex32` datatype is supported in a similar way, by casting to `int32`.

--- a/README.md
+++ b/README.md
@@ -367,6 +367,13 @@ The quantized datatypes (`qint8`, `qint32`, etc.) are not currently supported
 by tensorizer as they would require supplemental quantization parameters to be
 deserialized correctly.
 
+**NOTE:** The exact choice of intermediate types as `int16` and `int32` is
+considered an implementation detail, and is subject to change,
+so they should not be relied upon.
+
+**NOTE2:** This does not interfere with storing actual `int` datatypes
+used in tensors in tensorized files.
+
 ### Numpy Support
 
 Tensorizer can be used with `numpy` directly to read and write
@@ -398,6 +405,8 @@ has an opaque datatype and requires special handling (only legal when
 datatype that the raw data should be interpreted as in such cases.
 For all other datatypes that require no special handling, these are returned as
 `False` and `None`, respectively.
+The exact numpy datatypes used by the returned opaque `numpy.ndarray` objects
+is not guaranteed, and should not be relied upon.
 
 ## Running Tests
 `tensorizer` uses `unittest` for testing.

--- a/examples/hf_serialization.py
+++ b/examples/hf_serialization.py
@@ -229,11 +229,12 @@ def hf_main(args):
     print("MODEL PATH:", args.input_directory)
     print("OUTPUT PREFIX:", output_prefix)
 
+    dtype = torch.float16
     model_config = AutoConfig.from_pretrained(args.input_directory)
     model = AutoModelForCausalLM.from_pretrained(
         args.input_directory,
         config=model_config,
-        torch_dtype=torch.float16,
+        torch_dtype=dtype,
         low_cpu_mem_usage=True,
     )
 
@@ -257,7 +258,7 @@ def hf_main(args):
             AutoConfig,
             None,
             device,
-            "float16",
+            dtype,
         ).eval()
         # test generation
         eos = tokenizer.eos_token_id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorizer"
-version = "1.2.0"
+version = "2.0.0"
 license = { text = "MIT License" }
 keywords = ["tensorizer", "machine learning", "serialization", "tensor", "pytorch"]
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorizer"
-version = "2.0.0"
+version = "1.2.0"
 license = { text = "MIT License" }
 keywords = ["tensorizer", "machine learning", "serialization", "tensor", "pytorch"]
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorizer"
-version = "1.1.1"
+version = "2.0.0"
 license = { text = "MIT License" }
 keywords = ["tensorizer", "machine learning", "serialization", "tensor", "pytorch"]
 authors = [

--- a/tensorizer/_NumpyTensor.py
+++ b/tensorizer/_NumpyTensor.py
@@ -1,0 +1,297 @@
+from typing import NamedTuple, Optional, Sequence
+
+import numpy
+import torch
+
+__all__ = ["_NumpyTensor"]
+
+
+_INTERMEDIATE_MAPPING = {
+    1: torch.int8,
+    2: torch.int16,
+    4: torch.int32,
+    8: torch.int64,
+}
+
+# torch types with no numpy equivalents
+# i.e. the only ones that need to be opaque
+# Uses a comprehension to filter out any dtypes
+# that don't exist in older torch versions
+_ASYMMETRIC_TYPES = {
+    getattr(torch, t)
+    for t in (
+        "bfloat16",
+        "quint8",
+        "qint8",
+        "qint32",
+        "quint4x2",
+        "quint2x4",
+        "complex32",
+    )
+    if hasattr(torch, t)
+}
+
+# These types aren't supported yet because they require supplemental
+# quantization parameters to deserialize correctly
+_UNSUPPORTED_TYPES = {
+    getattr(torch, t)
+    for t in (
+        "quint8",
+        "qint8",
+        "qint32",
+        "quint4x2",
+        "quint2x4",
+    )
+    if hasattr(torch, t)
+}
+
+_DECODE_MAPPING = {str(t): t for t in _ASYMMETRIC_TYPES}
+
+
+class _NumpyTensor(NamedTuple):
+    data: numpy.ndarray
+    numpy_dtype: str
+    torch_dtype: Optional[str]
+
+    @classmethod
+    def from_buffer(
+        cls,
+        numpy_dtype: str,
+        torch_dtype: Optional[str],
+        shape_list: Sequence,
+        buffer: memoryview,
+        offset: int = 0,
+    ) -> "_NumpyTensor":
+        """
+        Decodes a raw byte buffer into a `_NumpyTensor` given its numpy dtype,
+        its torch dtype, and its shape.
+
+        Args:
+            numpy_dtype: The encoded numpy dtype of the buffer.
+            torch_dtype: The encoded torch dtype of the buffer.
+            shape_list: The dimensions of the array represented by the buffer.
+            buffer: The raw byte buffer containing encoded array data,
+                as a memoryview.
+            offset: An optional offset into the buffer to start from.
+
+        Returns:
+            A `_NumpyTensor` object that can have `.to_tensor()` called on it
+            to receive a torch.Tensor.
+        """
+        data = numpy.ndarray.__new__(
+            numpy.memmap,
+            shape_list,
+            dtype=cls._decoder_dtype(numpy_dtype),
+            buffer=buffer,
+            offset=offset,
+        )
+        return cls(data=data, numpy_dtype=numpy_dtype, torch_dtype=torch_dtype)
+
+    @classmethod
+    def from_tensor(cls, tensor: torch.Tensor) -> "_NumpyTensor":
+        """
+        Converts a torch tensor into a `_NumpyTensor`.
+        May use an opaque dtype for the numpy array stored in
+        the ``data`` field if the tensor's torch dtype has no numpy equivalent.
+        See also: `_NumpyTensor.is_opaque`.
+
+        Args:
+            tensor: A torch tensor to convert to a `_NumpyTensor`.
+
+        Returns:
+            A `_NumpyTensor` with a `data` field holding a numpy array,
+            and `numpy_dtype` and torch_dtype` fields suitable for
+            record-keeping for serialization and deserialization.
+        """
+        if tensor.dtype in _UNSUPPORTED_TYPES:
+            raise NotImplementedError(
+                f"Serialization for {tensor.dtype} is not implemented."
+            )
+        torch_dtype = str(tensor.dtype)
+        tensor = tensor.cpu().detach()
+
+        if not cls._is_asymmetric(tensor.dtype):
+            try:
+                arr = tensor.numpy()
+                numpy_dtype = arr.dtype.str
+                return cls(
+                    data=arr, numpy_dtype=numpy_dtype, torch_dtype=torch_dtype
+                )
+            except TypeError:
+                # Not a known asymmetric type, but torch can't convert it
+                # so fall back to storing it as opaque data
+                pass
+
+        # Replace the dtype with some variety of int and mark as opaque data
+        size = tensor.element_size()
+        arr = tensor.view(cls._intermediate_type(size)).numpy()
+        numpy_dtype = arr.dtype.str.replace("i", "V")
+        return cls(data=arr, numpy_dtype=numpy_dtype, torch_dtype=torch_dtype)
+
+    @classmethod
+    def from_array(cls, arr: numpy.ndarray) -> "_NumpyTensor":
+        """
+        Converts a numpy array into a `_NumpyTensor`.
+        This leaves the data as-is, but finds correct values for
+        `numpy_dtype` and `torch_dtype`.
+
+        Args:
+            arr: A numpy array to convert to a `_NumpyTensor`.
+
+        Returns:
+            A `_NumpyTensor` with `arr` as its `data` field,
+            and `numpy_dtype` and torch_dtype` fields suitable for
+            record-keeping for serialization and deserialization.
+        """
+        try:
+            test_array = numpy.empty((), dtype=arr.dtype)
+            torch_dtype = torch.from_numpy(test_array).dtype
+        except TypeError as e:
+            # If something were serialized with this type,
+            # it wouldn't be able to be deserialized later.
+            raise TypeError(
+                f"Cannot serialize an array with dtype {arr.dtype.name}"
+                " as a _NumpyTensor."
+            ) from e
+        return cls(data=arr, numpy_dtype=arr.dtype.str, torch_dtype=torch_dtype)
+
+    def to_tensor(self) -> torch.Tensor:
+        """
+        Converts a `_NumpyTensor` to a ``torch.Tensor`` and reifies any opaque
+        data into the correct torch dtype.
+
+        Returns:
+            A ``torch.Tensor`` referring to the same data as the `data` field,
+            with a correct torch dtype.
+        """
+        if not self.is_opaque:
+            return torch.from_numpy(self.data)
+        else:
+            if not self.torch_dtype:
+                raise ValueError(
+                    "Tried to decode a tensor stored as opaque data, but no"
+                    " torch dtype was specified"
+                )
+            tensor_view = torch.from_numpy(self.data)
+            return tensor_view.view(self._decode_torch_dtype())
+
+    @property
+    def is_opaque(self):
+        """
+        Whether the ``self.data`` numpy array is opaque,
+        i.e. stored as generic data without a meaningful dtype.
+
+        Returns:
+            True if ``self.data`` is uninterpretable without conversion
+            to a tensor via `self.to_tensor()`, False otherwise.
+        """
+        return self._is_opaque(self.numpy_dtype)
+
+    @staticmethod
+    def _intermediate_type(size: int) -> torch.dtype:
+        """
+        Find a dtype to masquerade as that torch can convert to a numpy array.
+
+        Args:
+            size: The size of the dtype, in bytes.
+
+        Returns:
+            A ``torch.dtype`` for a tensor that torch can convert
+            to a numpy array via ``tensor.numpy()``.
+        """
+        try:
+            return _INTERMEDIATE_MAPPING[size]
+        except KeyError as e:
+            raise ValueError(
+                "Cannot create a numpy array with opaque elements of size"
+                f" {size} bytes"
+            ) from e
+
+    @classmethod
+    def _is_opaque(cls, numpy_dtype: str) -> bool:
+        """
+        A check to see if the dtype needs to be swapped while decoding,
+        based on whether the encoded dtype is in the opaque format
+        used by this class.
+
+        Args:
+            numpy_dtype: The numpy dtype, as encoded in a tensorized file.
+
+        Returns:
+            True if the encoded dtype is opaque, False otherwise.
+        """
+        return numpy.dtype(numpy_dtype).type == numpy.void
+
+    @classmethod
+    def _is_asymmetric(cls, torch_dtype: torch.dtype) -> bool:
+        """
+        A check to see if the dtype needs to be swapped while encoding,
+        based on whether numpy has a corresponding dtype or not.
+        This check is hardcoded, not dynamic, but up to date as of torch 2.0.
+
+        Args:
+            dtype: The torch dtype to check
+
+        Returns:
+            True if a class is known not to have a corresponding numpy dtype,
+            False otherwise.
+        """
+        return torch_dtype in _ASYMMETRIC_TYPES
+
+    @classmethod
+    def _decoder_dtype(cls, numpy_dtype: str):
+        """
+        Converts an opaque storage numpy dtype generated by this class
+        into one that numpy can properly decode.
+
+        NB: Even though a dtype like ``numpy.dtype("<V2")`` is valid,
+        referring to the ``void16`` pseudo-type, numpy does not respect
+        the endianness indicated in the type string when loading this way.
+        If changed from ``<V2`` to ``<i2`` to load it as an int, it works fine.
+
+        Args:
+            numpy_dtype: The encoded numpy dtype.
+
+        Returns:
+            A dtype suitable for passing to numpy
+        """
+        if cls._is_opaque(numpy_dtype):
+            return numpy_dtype.replace("V", "i")
+        else:
+            return numpy_dtype
+
+    def _decode_torch_dtype(self) -> torch.dtype:
+        """
+        Parses the `self.torch_dtype` field.
+
+        Returns: An instance of ``torch.dtype`` corresponding to the string
+            stored in `self.torch_dtype`.
+
+        Raises:
+            ValueError: If `self.torch_dtype` is not set, is not in the form
+                "torch.<dtype>", cannot be found in torch, or refers to
+                something other than a ``torch.dtype``.
+            TypeError: If `self.torch_dtype` is not a string.
+        """
+        # Quick route, table lookup for common types
+        dtype = _DECODE_MAPPING.get(self.torch_dtype)
+        if dtype is not None:
+            return dtype
+        else:
+            # Long route using getattr(), any other type
+            if not self.torch_dtype:
+                raise ValueError("Cannot decode an empty dtype.")
+            if not isinstance(self.torch_dtype, str):
+                raise TypeError("torch_dtype must be a string.")
+            module, *dtype_name = self.torch_dtype.split(".", 1)
+
+            # Ensure that it's actually "torch.something"
+            if module != "torch" or len(dtype_name) != 1:
+                raise ValueError(f"Invalid torch_dtype: {self.torch_dtype}")
+
+            dtype = getattr(torch, dtype_name[0])
+            # Ensure that it's a real dtype
+            if dtype is None or not isinstance(dtype, torch.dtype):
+                raise ValueError(f"Invalid torch_dtype: {self.torch_dtype}")
+
+            return dtype

--- a/tensorizer/_NumpyTensor.py
+++ b/tensorizer/_NumpyTensor.py
@@ -289,9 +289,15 @@ class _NumpyTensor(NamedTuple):
         if module != "torch" or len(dtype_name) != 1:
             raise ValueError(f"Invalid torch_dtype: {self.torch_dtype}")
 
-        dtype = getattr(torch, dtype_name[0])
-        # Ensure that it's a real dtype
-        if dtype is None or not isinstance(dtype, torch.dtype):
-            raise ValueError(f"Invalid torch_dtype: {self.torch_dtype}")
+        try:
+            dtype = getattr(torch, dtype_name[0])
+            # Ensure that it's a real dtype
+            if not isinstance(dtype, torch.dtype):
+                raise TypeError(
+                    "Provided torch_dtype is not an instance of torch.dtype"
+                    f" (type: {type(dtype).__name__})"
+                )
+        except (AttributeError, TypeError) as e:
+            raise ValueError(f"Invalid torch_dtype: {self.torch_dtype}") from e
 
         return dtype

--- a/tensorizer/_NumpyTensor.py
+++ b/tensorizer/_NumpyTensor.py
@@ -92,7 +92,7 @@ class _NumpyTensor(NamedTuple):
         """
         Converts a torch tensor into a `_NumpyTensor`.
         May use an opaque dtype for the numpy array stored in
-        the ``data`` field if the tensor's torch dtype has no numpy equivalent.
+        the `data` field if the tensor's torch dtype has no numpy equivalent.
         See also: `_NumpyTensor.is_opaque`.
 
         Args:

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -753,10 +753,12 @@ class TensorDeserializer(collections.abc.Mapping):
         )
         for module_idx, tensor_type, name, tensor in data:
             if tensor.is_opaque and not allow_raw_data:
+                np_dtype = tensor.data.dtype.str
                 raise ValueError(
-                    f"{name} has an opaque datatype: {tensor.torch_dtype}. "
+                    f"{name} has an opaque datatype: "
+                    f"(Torch: {tensor.torch_dtype}, Numpy: {np_dtype}). "
                     "Set `allow_raw_data=True` to return as a numpy array "
-                    f"with a datatype of {tensor.numpy_dtype}"
+                    f"with a datatype of {np_dtype}"
                 )
 
             arr = tensor.data

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -54,7 +54,7 @@ class TensorType(Enum):
     STATE_DICT = 2
 
 
-TENSORIZER_VERSION = 1
+TENSORIZER_VERSION = 2
 TENSORIZER_MAGIC = b"|TZR|"
 
 

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -597,7 +597,7 @@ class TensorDeserializer(collections.abc.Mapping):
                     raise ValueError("Can't deserialize a tensor with "
                                      "multiple opaque dtype separators "
                                      f"({OPAQUE_DTYPE_SEP!r}) in its dtype: "
-                                     f"{dtype}")
+                                     f"{dtype!r}")
 
                 # Read the shape amount, according to the serialized format.
                 # The shape length is 1 byte after the dtype end.

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -90,21 +90,19 @@ def _convert_dtype_to_torch(dtype: Union[numpy.dtype, str, torch.dtype]) -> torc
         dtype = numpy.dtype(dtype)
 
     if isinstance(dtype, numpy.dtype):
-        # Converted from PyTorch's own mapping used in their testing:
-        # https://github.com/pytorch/pytorch/blob/v2.0.0/torch/testing/_internal/common_utils.py#L1009
         torch_dtype = {
-            numpy.bool_: torch.bool,
-            numpy.uint8: torch.uint8,
-            numpy.int8: torch.int8,
-            numpy.int16: torch.int16,
-            numpy.int32: torch.int32,
-            numpy.int64: torch.int64,
-            numpy.float16: torch.float16,
-            numpy.float32: torch.float32,
-            numpy.float64: torch.float64,
-            numpy.complex64: torch.complex64,
-            numpy.complex128: torch.complex128,
-        }.get(dtype)
+            "|b1": torch.bool,
+            "|u1": torch.uint8,
+            "|i1": torch.int8,
+            "<i2": torch.int16,
+            "<i4": torch.int32,
+            "<i8": torch.int64,
+            "<f2": torch.float16,
+            "<f4": torch.float32,
+            "<f8": torch.float64,
+            "<c8": torch.complex64,
+            "<c16": torch.complex128,
+        }.get(dtype.str)
 
         if torch_dtype is None:
             raise TypeError(

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -15,7 +15,7 @@ os.environ["TOKENIZERS_PARALLELISM"] = (
 
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 
-from tensorizer import TensorDeserializer, TensorSerializer, utils, stream_io
+from tensorizer import TensorDeserializer, TensorSerializer, stream_io, utils
 from tensorizer.serialization import TensorType
 
 model_name = "EleutherAI/gpt-neo-125M"
@@ -118,9 +118,9 @@ class TestSerialization(unittest.TestCase):
                     os.unlink(serialized_model)
 
     def test_bfloat16(self):
-        tensorized_file = tempfile.NamedTemporaryFile("wb+", delete=False)
         shape = (50, 50)
         tensor = torch.normal(0, 0.5, shape, dtype=torch.bfloat16)
+        tensorized_file = tempfile.NamedTemporaryFile("wb+", delete=False)
 
         try:
             serializer = TensorSerializer(tensorized_file)
@@ -129,19 +129,16 @@ class TestSerialization(unittest.TestCase):
 
             with open(tensorized_file.name, "rb") as in_file:
                 deserializer = TensorDeserializer(
-                    in_file,
-                    device="cpu",
-                    lazy_load=True
+                    in_file, device="cpu", lazy_load=True
                 )
                 deserialized_tensor = [
-                    t for t in
-                    deserializer.read_tensors(num_tensors=1)
+                    t for t in deserializer.read_tensors(num_tensors=1)
                 ][0][-1]
                 deserializer.close()
         finally:
             os.unlink(tensorized_file.name)
 
-        assert(torch.equal(tensor, deserialized_tensor))
+        assert torch.equal(tensor, deserialized_tensor)
 
 
 class TestDeserialization(unittest.TestCase):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -227,7 +227,7 @@ class TestDeserialization(unittest.TestCase):
 
         deserialized.close()
 
-    @patch.object(stream_io, "_s3_default_config_paths", {})
+    @patch.object(stream_io, "_s3_default_config_paths", ())
     def test_s3(self):
         deserialized = TensorDeserializer(
             f"s3://tensorized/{model_name}/model.tensors", device=default_device
@@ -236,7 +236,7 @@ class TestDeserialization(unittest.TestCase):
         check_inference(deserialized, model_name, default_device)
         deserialized.close()
 
-    @patch.object(stream_io, "_s3_default_config_paths", {})
+    @patch.object(stream_io, "_s3_default_config_paths", ())
     def test_s3_fp16(self):
         deserialized = TensorDeserializer(
             f"s3://tensorized/{model_name}/fp16/model.tensors",
@@ -248,7 +248,7 @@ class TestDeserialization(unittest.TestCase):
             check_inference(deserialized, model_name, default_device)
         deserialized.close()
 
-    @patch.object(stream_io, "_s3_default_config_paths", {})
+    @patch.object(stream_io, "_s3_default_config_paths", ())
     def test_s3_lazy_load(self):
         deserialized = TensorDeserializer(
             f"s3://tensorized/{model_name}/model.tensors",

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -22,10 +22,6 @@ model_name = "EleutherAI/gpt-neo-125M"
 num_hellos = 400
 is_cuda_available = torch.cuda.is_available()
 default_device = "cuda" if is_cuda_available else "cpu"
-s3_credentials = stream_io._ParsedCredentials(s3_endpoint="accel-object.ord1.coreweave.com",
-                                              config_file="",
-                                              s3_access_key="",
-                                              s3_secret_key="")
 
 
 def serialize_model(model_name: str, device: str) -> Tuple[str, dict]:
@@ -243,9 +239,8 @@ class TestDeserialization(unittest.TestCase):
         check_inference(deserialized, model_name, default_device)
         deserialized.close()
 
-    @patch("tensorizer.stream_io._infer_credentials")
-    def test_s3_fp16(self, credentials_mock):
-        credentials_mock.return_value = s3_credentials
+    @patch.object(stream_io, "_s3_default_config_paths", {})
+    def test_s3_fp16(self):
         deserialized = TensorDeserializer(
             f"s3://tensorized/{model_name}/fp16/model.tensors",
             device=default_device,
@@ -256,9 +251,8 @@ class TestDeserialization(unittest.TestCase):
             check_inference(deserialized, model_name, default_device)
         deserialized.close()
 
-    @patch("tensorizer.stream_io._infer_credentials")
-    def test_s3_lazy_load(self, credentials_mock):
-        credentials_mock.return_value = s3_credentials
+    @patch.object(stream_io, "_s3_default_config_paths", {})
+    def test_s3_lazy_load(self):
         deserialized = TensorDeserializer(
             f"s3://tensorized/{model_name}/model.tensors",
             device=default_device,

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -131,8 +131,15 @@ class TestSerialization(unittest.TestCase):
 
         try:
             with open(tensorized_file.name, "rb") as in_file:
-                deserializer = TensorDeserializer(in_file, device="cpu", lazy_load=True)
-                deserialized_tensor = [t for t in deserializer.read_tensors(num_tensors=1)][0][-1]
+                deserializer = TensorDeserializer(
+                    in_file,
+                    device="cpu",
+                    lazy_load=True
+                )
+                deserialized_tensor = [
+                    t for t in
+                    deserializer.read_tensors(num_tensors=1)
+                ][0][-1]
                 deserializer.close()
         finally:
             os.unlink(tensorized_file.name)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -125,11 +125,12 @@ class TestSerialization(unittest.TestCase):
         tensorized_file = tempfile.NamedTemporaryFile("wb+", delete=False)
         shape = (50, 50)
         tensor = torch.normal(0, 0.5, shape, dtype=torch.bfloat16)
-        serializer = TensorSerializer(tensorized_file)
-        serializer.write_tensor(0, "test_tensor", TensorType.PARAM, tensor)
-        serializer.close()
 
         try:
+            serializer = TensorSerializer(tensorized_file)
+            serializer.write_tensor(0, "test_tensor", TensorType.PARAM, tensor)
+            serializer.close()
+
             with open(tensorized_file.name, "rb") as in_file:
                 deserializer = TensorDeserializer(
                     in_file,
@@ -233,10 +234,8 @@ class TestDeserialization(unittest.TestCase):
 
         deserialized.close()
 
-    @patch("tensorizer.stream_io._infer_credentials")
-    def test_s3(self, credentials_mock):
-        credentials_mock.return_value = s3_credentials
-
+    @patch.object(stream_io, "_s3_default_config_paths", {})
+    def test_s3(self):
         deserialized = TensorDeserializer(
             f"s3://tensorized/{model_name}/model.tensors", device=default_device
         )


### PR DESCRIPTION
This PR adds support for models using `torch.bfloat16`.

### Overview
Tensorizer uses numpy to save the tensors as binary and numpy doesn't support `bfloat16`. This means that special conversions need to be applied which decreases the performance of both serialization and deserialization.

To be saved, the torch tensor is cast to fp32, adding an additional 16 bits. This value is converted to numpy, then bit shifted and cast down to a `np.uint16` to save the original 16 bits from torch's `bfloat16`. The reverse happens during the deserialization process.

### Benchmarks
Datapoints are averages over 5 runs and use GPT-J-6B cast to the respective precision. All were run on pods with the same CPU/RAM/GPU and were reading/writing the files from a PVC.
| Process         | fp16    | bfloat16 |
|-----------------|---------|----------|
| Serialization   | 116.63s | 172.90s  |
| Deserialization | 2.00s   | 9.25s    |

### Numpy vs Torch dtypes
Previously, the deserializer would pass around numpy arrays and dtypes. This makes things more complicated when there isn't a 1 to 1 mapping of numpy dtype to torch dtype.

For example, the "global dtype" that could be passed into the deserializer (specifying a datatype to cast everything to ignoring the metadata) was saved as a numpy datatype. Since the set of supported torch datatypes is not a 1 to 1 mapping to numpy, this was changed to be stored as a torch datatype.

The `read_tensors` function now also deals with numpy to torch tensor conversion instead of leaving that to the `_to_torch_parameter` downstream.


