### PR TITLE
feat: `read_numpy_arrays()` improvements, deserialization bug fix, and more comprehensive docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,29 +370,34 @@ deserialized correctly.
 ### Numpy Support
 
 Tensorizer can be used with `numpy` directly to read and write
-`numpy.ndarray`'s.
+`numpy.ndarray`s.
 
 The serializer's `write_tensor` function handles supplying both
-`torch.Tensor`'s and `numpy.ndarray`'s.
+`torch.Tensor`s and `numpy.ndarray`s.
 
 The deserializer has a separate function `read_numpy_arrays` that will return
-the data as `numpy.ndarray`'s.
+the data as `numpy.ndarray`s.
 
 As explained above in [bfloat16 support](#bfloat16-support), tensorizer uses
-special conversions to write opaque datatypes, those not supported by numpy.
-Therefore, special considerations need to be taken when loading the data as
-`numpy.ndarray`'s.
+special conversions to write "opaque" datatypes, those not supported by numpy.
+Therefore, special considerations need to be taken when loading such data as
+`numpy.ndarray`s.
 
-By default, the `read_numpy_arrays` function sets its `allow_raw_data`
-parameter to `False`. This means that if the data contains opaque datatypes,
-a `ValueError` will be raised.
+By default, the `TensorDeserializer.read_numpy_arrays` function sets its
+`allow_raw_data` parameter to `False`. This means that if a file contains
+opaque datatypes, a `ValueError` will be raised during deserialization.
 
-If you want to return the raw data regardless, set `allow_raw_data` to be
-`True`.
+If you want to return the raw data regardless, set `allow_raw_data` to `True`.
+Otherwise, the file may be read with `TensorDeserializer.read_tensors`
+instead, which yields `torch.Tensor` objects of the correct datatype.
 
-A fifth variable is returned by the `read_numpy_arrays` generator, which is a
-`bool` that indicates whether the returned data was originally an opaque
-datatype.
+A fifth and sixth variable are also returned by the `read_numpy_arrays`
+generator. The fifth is a `bool` that indicates whether the returned array
+has an opaque datatype and requires special handling (only legal when
+`allow_raw_data=True`). The sixth is a string describing the true, non-numpy
+datatype that the raw data should be interpreted as in such cases.
+For all other datatypes that require no special handling, these are returned as
+`False` and `None`, respectively.
 
 ## Running Tests
 `tensorizer` uses `unittest` for testing.

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -532,7 +532,7 @@ class TensorDeserializer(collections.abc.Mapping):
     ) -> Iterator[Tuple[int, int, str, _NumpyTensor]]:
         """
         A generator that deserializes tensors and returns the `module_idx`,
-        `tensor_type`, parameter/buffer `name`, and a NumpyTensor `tensor`.
+        `tensor_type`, parameter/buffer `name`, and a _NumpyTensor `tensor`.
 
         Note that this function does not seek to the beginning of the tensor
         data. It assumes that the file pointer is already at the beginning
@@ -687,7 +687,7 @@ class TensorDeserializer(collections.abc.Mapping):
     ) -> Iterator[Tuple[int, int, str, torch.Tensor]]:
         """
         A generator that deserializes tensors and returns the `module_idx`,
-        `tensor_type`, parameter/buffer `name`, and the torch tensor.
+        `tensor_type`, parameter/buffer `name`, and torch `tensor`.
 
         Note that this function does not seek to the beginning of the tensor
         data. It assumes that the file pointer is already at the beginning
@@ -706,6 +706,9 @@ class TensorDeserializer(collections.abc.Mapping):
                 will be read. If the zero-byte header is encountered before
                 `num_tensors` tensors are read, the generator will stop
                 yielding values.
+
+        Yields:
+            Tuples of the form (module_idx, tensor_type, name, tensor).
         """
 
         data = self._read_numpytensors(
@@ -719,11 +722,38 @@ class TensorDeserializer(collections.abc.Mapping):
         filter_func: Optional[Callable[[str], Union[bool, Any]]] = None,
         num_tensors: int = -1,
         allow_raw_data: bool = False,
-    ) -> Iterator[Tuple[int, int, str, numpy.ndarray, bool]]:
+    ) -> Iterator[Tuple[int, int, str, numpy.ndarray, bool, Optional[str]]]:
         """
         A generator that deserializes tensors and returns the `module_idx`,
-        `tensor_type`, parameter/buffer `name`, and the numpy `arr` that
-        represents the tensor.
+        `tensor_type`, parameter/buffer `name`, the numpy `arr` that
+        represents the tensor, a boolean representing if the returned datatype
+        is opaque, and the name of the true datatype represented by the opaque
+        data, if applicable.
+
+
+        "Opaque data" refers to numpy arrays holding accurate raw binary data
+        but an invalid dtype attribute, occurring when there is no numpy dtype
+        corresponding to the original type that was serialized.
+        These are only returned if `allow_raw_data` is set to `True`,
+        otherwise, encountering such a datatype is an error,
+        and the file should instead be deserialized with
+        `TensorDeserializer.read_tensors()`.
+
+        For example, if a ``torch.Tensor`` with the dtype ``torch.bfloat16``
+        is serialized, then it can be accurately deserialized using
+        `TensorDeserializer.read_tensors()`. Since there is no numpy type
+        corresponding to ``torch.bfloat16``, attempting to deserialize the same
+        file via `TensorDeserializer.read_numpy_arrays()` will raise a
+        ``ValueError``.
+        However, if `allow_raw_data` is set to ``True``, then
+        `TensorDeserializer.read_numpy_arrays()` will return these
+        arrays regardless, and the final two values of the yielded tuple,
+        `is_opaque` and `torch_dtype`, will be ``True`` and a string
+        representing the true non-numpy datatype represented by the data,
+        respectively. Special handling is then required to use the returned
+        data accurately.
+
+
 
         Note that this function does not seek to the beginning of the tensor
         data. It assumes that the file pointer is already at the beginning
@@ -733,7 +763,9 @@ class TensorDeserializer(collections.abc.Mapping):
         if `num_tensors` is -1.
 
         The generator yields tuples of the form:
-            (module_idx, tensor_type, name, arr, is_opaque)
+            (module_idx, tensor_type, name, arr, is_opaque, torch_dtype)
+
+        See also: `TensorDeserializer.read_tensors`
 
         Args:
             filter_func: A function that takes a tensor name and returns
@@ -742,18 +774,42 @@ class TensorDeserializer(collections.abc.Mapping):
                 will be read. If the zero-byte header is encountered before
                 `num_tensors` tensors are read, the generator will stop
                 yielding values.
-            allow_raw_data: Whether to return numpy arrays that contain
-                represent opaque datatypes. If not allowed and an opaque
-                NumpyTensor is encountered, then a `ValueError` is raised.
+            allow_raw_data: Whether to return numpy arrays containing
+                uninterpretable opaque datatypes. If False and opaque
+                datatypes are encountered, then a `ValueError` is raised.
                 Defaults to False.
+
+        Yields:
+            Tuples of the form:
+            (
+                module_idx,
+                tensor_type,
+                name,
+                arr,
+                is_opaque,
+                torch_dtype
+            )
+            If the `allow_raw_data` parameter is ``False`` (the default),
+            the final two elements are always ``False`` and ``None``,
+            respectively. Otherwise, ``is_opaque`` may be ``True``, and
+            ``torch_dtype`` will then be a string representing the actual
+            non-numpy datatype represented by the data in `arr`.
+
+        Raises:
+            ValueError: If an opaque datatype is encountered in the file
+                and ``allow_raw_data=False``.
         """
 
         data = self._read_numpytensors(
             filter_func=filter_func, num_tensors=num_tensors
         )
         for module_idx, tensor_type, name, tensor in data:
-            if tensor.is_opaque and not allow_raw_data:
-                np_dtype = tensor.data.dtype.str
+            is_opaque = tensor.is_opaque
+            arr = tensor.data
+            torch_dtype = tensor.torch_dtype if is_opaque else None
+
+            if is_opaque and not allow_raw_data:
+                np_dtype = arr.dtype.str
                 raise ValueError(
                     f"{name} has an opaque datatype: "
                     f"(Torch: {tensor.torch_dtype}, Numpy: {np_dtype}). "
@@ -761,8 +817,7 @@ class TensorDeserializer(collections.abc.Mapping):
                     f"with a datatype of {np_dtype}"
                 )
 
-            arr = tensor.data
-            yield module_idx, tensor_type, name, arr, tensor.is_opaque
+            yield module_idx, tensor_type, name, arr, is_opaque, torch_dtype
 
     def _to_torch_parameter(
         self, tensor: Union[torch.Tensor, torch.nn.Parameter]

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -674,6 +674,8 @@ class TensorDeserializer(collections.abc.Mapping):
                     mv,
                 )
 
+                tensors_read += 1
+
                 yield module_idx, tensor_type, name, tensor
         except EOFError:
             return
@@ -707,8 +709,7 @@ class TensorDeserializer(collections.abc.Mapping):
         """
 
         data = self._read_numpytensors(
-            filter_func=filter_func,
-            num_tensors=num_tensors
+            filter_func=filter_func, num_tensors=num_tensors
         )
         for module_idx, tensor_type, name, tensor in data:
             yield module_idx, tensor_type, name, tensor.to_tensor()
@@ -748,8 +749,7 @@ class TensorDeserializer(collections.abc.Mapping):
         """
 
         data = self._read_numpytensors(
-            filter_func=filter_func,
-            num_tensors=num_tensors
+            filter_func=filter_func, num_tensors=num_tensors
         )
         for module_idx, tensor_type, name, tensor in data:
             if tensor.is_opaque and not allow_raw_data:


### PR DESCRIPTION
Improvements and a bug fix for #27. This PR:
- Adds `torch_dtype` information as an `Optional[str]` to the tuple returned by `TensorDeserializer.read_numpy_arrays()` when the returned array consists of opaque data
- Updates the README accordingly
- Expands the docstrings for `TensorDeserializer.read_numpy_arrays()` and `TensorDeserializer.read_tensors()` to be more comprehensive, and
- Fixes a bug where the `num_tensors` parameter of neither function was honoured.