### PR TITLE
fix: Support unsigned S3 requests & non-persistent buffers better

### DIFF
--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, Optional, Tuple, Union
 from urllib.parse import urlparse
 
 import boto3
+import botocore
 
 import tensorizer._wide_pipes as _wide_pipes
 
@@ -367,12 +368,10 @@ def _ensure_https_endpoint(endpoint: str):
         raise ValueError("Non-HTTPS endpoint URLs are not allowed.")
 
 
-def s3_upload(
-    path: str,
-    target_uri: str,
+def _new_s3_client(
     s3_access_key_id: str,
     s3_secret_access_key: str,
-    s3_endpoint: str = default_s3_write_endpoint,
+    s3_endpoint: str,
 ):
     if s3_secret_access_key is None:
         raise TypeError("No secret key provided")
@@ -381,16 +380,35 @@ def s3_upload(
     if s3_endpoint is None:
         raise TypeError("No S3 endpoint provided")
 
-    client = boto3.session.Session.client(
+    if s3_access_key_id == s3_secret_access_key == "":
+        auth_args = dict(
+            config=boto3.session.Config(signature_version=botocore.UNSIGNED)
+        )
+    else:
+        auth_args = dict(
+            aws_access_key_id=s3_access_key_id,
+            aws_secret_access_key=s3_secret_access_key,
+        )
+
+    return boto3.session.Session.client(
         boto3.session.Session(),
         endpoint_url=_ensure_https_endpoint(s3_endpoint),
         service_name="s3",
-        aws_access_key_id=s3_access_key_id,
-        aws_secret_access_key=s3_secret_access_key,
+        **auth_args,
     )
+
+
+def s3_upload(
+    path: str,
+    target_uri: str,
+    s3_access_key_id: str,
+    s3_secret_access_key: str,
+    s3_endpoint: str = default_s3_write_endpoint,
+):
     path_uri = urlparse(target_uri)
     bucket = path_uri.netloc
     key = path_uri.path.lstrip("/")
+    client = _new_s3_client(s3_access_key_id, s3_secret_access_key, s3_endpoint)
 
     client.upload_file(path, bucket, key)
 
@@ -401,23 +419,10 @@ def s3_download(
     s3_secret_access_key: str,
     s3_endpoint: str = default_s3_read_endpoint,
 ) -> CURLStreamFile:
-    if s3_secret_access_key is None:
-        raise TypeError("No secret key provided")
-    if s3_access_key_id is None:
-        raise TypeError("No access key provided")
-    if s3_endpoint is None:
-        raise TypeError("No S3 endpoint provided")
-
-    client = boto3.session.Session.client(
-        boto3.session.Session(),
-        endpoint_url=_ensure_https_endpoint(s3_endpoint),
-        service_name="s3",
-        aws_access_key_id=s3_access_key_id,
-        aws_secret_access_key=s3_secret_access_key,
-    )
     path_uri = urlparse(path_uri)
     bucket = path_uri.netloc
     key = path_uri.path.lstrip("/")
+    client = _new_s3_client(s3_access_key_id, s3_secret_access_key, s3_endpoint)
 
     url = client.generate_presigned_url(
         ClientMethod="get_object",

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -398,6 +398,17 @@ def _new_s3_client(
     )
 
 
+def _parse_s3_uri(uri: str) -> Tuple[str, str]:
+    uri_components = urlparse(uri)
+
+    if uri_components.scheme.lower() != "s3":
+        raise ValueError(f"Invalid S3 URI: {uri}")
+
+    bucket = uri_components.netloc
+    key = uri_components.path.lstrip("/")
+    return bucket, key
+
+
 def s3_upload(
     path: str,
     target_uri: str,
@@ -405,11 +416,8 @@ def s3_upload(
     s3_secret_access_key: str,
     s3_endpoint: str = default_s3_write_endpoint,
 ):
-    path_uri = urlparse(target_uri)
-    bucket = path_uri.netloc
-    key = path_uri.path.lstrip("/")
+    bucket, key = _parse_s3_uri(target_uri)
     client = _new_s3_client(s3_access_key_id, s3_secret_access_key, s3_endpoint)
-
     client.upload_file(path, bucket, key)
 
 
@@ -419,11 +427,8 @@ def s3_download(
     s3_secret_access_key: str,
     s3_endpoint: str = default_s3_read_endpoint,
 ) -> CURLStreamFile:
-    path_uri = urlparse(path_uri)
-    bucket = path_uri.netloc
-    key = path_uri.path.lstrip("/")
+    bucket, key = _parse_s3_uri(path_uri)
     client = _new_s3_client(s3_access_key_id, s3_secret_access_key, s3_endpoint)
-
     url = client.generate_presigned_url(
         ClientMethod="get_object",
         Params={"Bucket": bucket, "Key": key},


### PR DESCRIPTION
# Unsigned S3 Requests & Non-Persistent Module Buffers

This change fixes two bugs:

- Newer versions of boto3/botocore take issue with our method of providing blank (empty string) keys to indicate public buckets.
  - This is fixed by switching to use completely unsigned S3 URLs for public buckets.
- Our `tests/test_serialization.check_deserialized()` check has been failing because tensorizer doesn't match PyTorch's behaviour with non-persistent buffers in state dicts.
 - Normally, a buffer in a module registered with `module.register_buffer(..., persistent=False)` does not appear in subsequent calls to `module.state_dict()`
 - The contents of these are intended to be generated at runtime ([see the original proposal here](https://github.com/pytorch/pytorch/issues/18056))
 - `tensorizer` serializes and deserializes these like any other buffers, so the deserialized state is not directly comparable with a corresponding call to `module.state_dict()`
 - Whether or not these buffers *should* be serialized is a separate question (since the `no_init_or_tensor()` idiom used when loading `.tensors` files might suppress their normal runtime initialization)—but this change compares them during tests.