### PR TITLE
fix: Hash Verification Fixes & Polish

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: ^.*_pb2\.py|ATTIC/.*$
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
       - id: black
         language_version: python3.10

--- a/examples/benchmark/deserialize_benchmark.py
+++ b/examples/benchmark/deserialize_benchmark.py
@@ -1,11 +1,13 @@
-import torch
-import shutil
 import os
+import shutil
 import time
 from pathlib import Path
+
+import numpy as np
+import torch
+
 from tensorizer import TensorDeserializer
 from tensorizer.utils import convert_bytes, get_mem_usage
-import numpy as np
 
 # disable missing keys and unexpected key warnings
 os.environ["TRANSFORMERS_VERBOSITY"] = "error"
@@ -14,7 +16,7 @@ os.environ["TRANSFORMERS_VERBOSITY"] = "error"
 os.environ["SAFETENSORS_FAST_GPU"] = "1"
 
 from accelerate import init_empty_weights
-from transformers import AutoModelForCausalLM, AutoTokenizer, AutoConfig
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 
 
 def convert_to_bool(val: str) -> bool:
@@ -69,7 +71,7 @@ def hf_load() -> float:
         low_cpu_mem_usage=True,
         config=config,
         use_safetensors=False,
-        device_map="auto"
+        device_map="auto",
     )
     duration = time.time() - start
 
@@ -119,7 +121,7 @@ def st_load() -> float:
         low_cpu_mem_usage=True,
         config=config,
         use_safetensors=True,
-        device_map="auto"
+        device_map="auto",
     )
     end = time.time()
 
@@ -138,7 +140,9 @@ def st_load() -> float:
 if not SKIP_TZR:
     print("\nRunning Tensorizer...")
     tzr_times = [tzr_load() for _ in range(NUM_TRIALS)]
-    print("Average tensorizer deserialization:", sum(tzr_times) / len(tzr_times))
+    print(
+        "Average tensorizer deserialization:", sum(tzr_times) / len(tzr_times)
+    )
     with open(RES_PATH / f"tzr_times_{time.time()}.npy", "wb") as f:
         np.save(f, np.array(tzr_times))
 

--- a/examples/benchmark/save_models.py
+++ b/examples/benchmark/save_models.py
@@ -1,17 +1,24 @@
-import time
 import os
-from typing import Optional, Dict, List
-
-import torch
+import time
 from collections import defaultdict
 from pathlib import Path
-from tensorizer import TensorSerializer
-from transformers import AutoModelForCausalLM, AutoTokenizer
+from typing import Dict, List, Optional
+
+import torch
 from safetensors.torch import save_file
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from tensorizer import TensorSerializer
 
 MODEL_ID = os.environ.get("MODEL_ID", "EleutherAI/gpt-neo-125M")
 MODEL_PATH = Path(os.environ.get("MODEL_PATH", "./models"))
-USE_FP16 = os.environ.get("USE_FP16", "").strip().lower() not in ("", "0", "no", "f", "false")
+USE_FP16 = os.environ.get("USE_FP16", "").strip().lower() not in (
+    "",
+    "0",
+    "no",
+    "f",
+    "false",
+)
 NUM_TRIALS = int(os.environ.get("NUM_TRIALS", 1))
 
 if USE_FP16:
@@ -44,8 +51,7 @@ def shared_pointers(tensors) -> List:
 
 
 def convert_shared_tensors(
-    pt_filename: Optional[str] = None,
-    state_dict=None
+    pt_filename: Optional[str] = None, state_dict=None
 ) -> Dict:
     """
     Clone data shared between tensors.
@@ -90,7 +96,10 @@ def save_tzr() -> float:
     serializer.close()
     end = time.time()
 
-    print(f"Serialized {serializer.total_tensor_bytes} btyes in {end - start:0.2f}s")
+    print(
+        f"Serialized {serializer.total_tensor_bytes} bytes in"
+        f" {end - start:0.2f}s"
+    )
     return end - start
 
 

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -119,7 +119,7 @@ class TensorDeserializer(collections.abc.Mapping):
             naughtiness of reusing a backing buffer. This is only recommended
             for use with inference, and not training.
         verify_hash: If True, the hashes of each tensor will be verified
-            against the hashes stored in the metadata. A HashMismatchError
+            against the hashes stored in the metadata. A `HashMismatchError`
             will be raised if any of the hashes do not match.
 
     Examples:
@@ -171,7 +171,7 @@ class TensorDeserializer(collections.abc.Mapping):
             os.PathLike,
             int,
         ],
-        device: Union[torch.device, str, None] = None,
+        device: Optional[Union[torch.device, str]] = None,
         filter_func: Optional[Callable[[str], Union[bool, Any]]] = None,
         dtype: Optional[torch.dtype] = None,
         *,
@@ -602,7 +602,7 @@ class TensorDeserializer(collections.abc.Mapping):
         self,
         filter_func: Optional[Callable[[str], Union[bool, Any]]] = None,
         num_tensors: int = -1,
-        verify_hash: Union[bool, None] = None,
+        verify_hash: Optional[bool] = None,
     ) -> Iterator[Tuple[int, int, str, _NumpyTensor]]:
         """
         A generator that deserializes tensors and returns the `module_idx`,
@@ -815,7 +815,7 @@ class TensorDeserializer(collections.abc.Mapping):
         filter_func: Optional[Callable[[str], Union[bool, Any]]] = None,
         num_tensors: int = -1,
         allow_raw_data: bool = False,
-        verify_hash: Union[bool, None] = None,
+        verify_hash: Optional[bool] = None,
     ) -> Iterator[Tuple[int, int, str, numpy.ndarray, bool, Optional[str]]]:
         """
         A generator that deserializes tensors and returns the `module_idx`,
@@ -962,7 +962,7 @@ class TensorDeserializer(collections.abc.Mapping):
         self,
         m: torch.nn.Module,
         filter_func: Optional[Callable[[str], Union[bool, Any]]] = None,
-        verify_hash: Union[bool, None] = None,
+        verify_hash: Optional[bool] = None,
     ) -> int:
         """
         Given `m`, a torch.nn.Module, load the associate tensors in this

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -33,6 +33,7 @@ num_hellos = 400
 is_cuda_available = torch.cuda.is_available()
 default_device = "cuda" if is_cuda_available else "cpu"
 salt = secrets.token_bytes(4)
+default_read_endpoint = "object.ord1.coreweave.com"
 
 
 def serialize_model(model_name: str, device: str) -> Tuple[str, dict]:
@@ -298,6 +299,7 @@ class TestDeserialization(unittest.TestCase):
         deserialized.close()
 
     @patch.object(stream_io, "_s3_default_config_paths", ())
+    @patch.object(stream_io, "default_s3_read_endpoint", default_read_endpoint)
     def test_s3(self):
         deserialized = TensorDeserializer(
             f"s3://tensorized/{model_name}/model.tensors", device=default_device
@@ -307,6 +309,7 @@ class TestDeserialization(unittest.TestCase):
         deserialized.close()
 
     @patch.object(stream_io, "_s3_default_config_paths", ())
+    @patch.object(stream_io, "default_s3_read_endpoint", default_read_endpoint)
     def test_s3_fp16(self):
         deserialized = TensorDeserializer(
             f"s3://tensorized/{model_name}/fp16/model.tensors",
@@ -319,6 +322,7 @@ class TestDeserialization(unittest.TestCase):
         deserialized.close()
 
     @patch.object(stream_io, "_s3_default_config_paths", ())
+    @patch.object(stream_io, "default_s3_read_endpoint", default_read_endpoint)
     def test_s3_lazy_load(self):
         deserialized = TensorDeserializer(
             f"s3://tensorized/{model_name}/model.tensors",

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,10 +1,14 @@
 import contextlib
+import ctypes
+import functools
 import gc
+import hashlib
 import os
 import re
+import secrets
 import tempfile
 import unittest
-from typing import Tuple
+from typing import Mapping, NamedTuple, Tuple
 from unittest.mock import patch
 
 import torch
@@ -15,13 +19,20 @@ os.environ["TOKENIZERS_PARALLELISM"] = (
 
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 
-from tensorizer import TensorDeserializer, TensorSerializer, stream_io, utils
-from tensorizer.serialization import TensorType
+from tensorizer import (
+    TensorDeserializer,
+    TensorSerializer,
+    serialization,
+    stream_io,
+    utils,
+)
+from tensorizer.serialization import TensorHash, TensorType
 
 model_name = "EleutherAI/gpt-neo-125M"
 num_hellos = 400
 is_cuda_available = torch.cuda.is_available()
 default_device = "cuda" if is_cuda_available else "cpu"
+salt = secrets.token_bytes(4)
 
 
 def serialize_model(model_name: str, device: str) -> Tuple[str, dict]:
@@ -38,28 +49,80 @@ def serialize_model(model_name: str, device: str) -> Tuple[str, dict]:
     return out_file.name, sd
 
 
-def check_deserialized(deserialized, model_name: str, allow_subset=False):
+# Reducing a tensor to a hash makes it faster to compare against the reference
+# model in many repeated tests
+class TensorInfo(NamedTuple):
+    size: int
+    dtype: torch.dtype
+    hash: bytes
+
+    @classmethod
+    def from_tensor(cls, tensor: torch.Tensor) -> "TensorInfo":
+        storage = tensor.untyped_storage().cpu()
+        data = ctypes.cast(
+            storage.data_ptr(),
+            ctypes.POINTER(ctypes.c_ubyte * storage.nbytes()),
+        ).contents
+        hash_val = hashlib.blake2b(data, digest_size=16, salt=salt).digest()
+        return cls(size=tensor.size(), dtype=tensor.dtype, hash=hash_val)
+
+
+@functools.lru_cache(maxsize=None)
+def model_digest(model_name: str) -> Mapping[str, TensorInfo]:
     orig_model = AutoModelForCausalLM.from_pretrained(model_name)
     orig_sd = orig_model.state_dict()
     # Non-persistent buffers are serialized in tensorizer,
     # but aren't included in a state_dict() in PyTorch.
     orig_sd.update(orig_model.named_buffers())
+    return {k: TensorInfo.from_tensor(v) for k, v in orig_sd.items()}
+
+
+def check_deserialized(
+    test_case: unittest.TestCase,
+    deserialized: TensorDeserializer,
+    model_name: str,
+    allow_subset: bool = False,
+):
+    orig_sd = model_digest(model_name)
+
     if not allow_subset:
-        assert orig_sd.keys() == deserialized.keys()
+        test_case.assertEqual(
+            orig_sd.keys(),
+            deserialized.keys(),
+            "List of deserialized keys doesn't match list of original keys",
+        )
+
     for k, v in deserialized.items():
-        # fmt: off
-        assert k in orig_sd, \
-            f"{k} not in {orig_sd.keys()}"
+        test_case.assertIn(
+            k,
+            orig_sd,
+            f"Key not from original: {k} not in {orig_sd.keys()}",
+        )
 
-        assert v.size() == orig_sd[k].size(), \
-            f"{v.size()} != {orig_sd[k].size()}"
+        v_info = TensorInfo.from_tensor(v)
+        orig_info = orig_sd[k]
 
-        assert v.dtype == orig_sd[k].dtype, \
-            f"{v.dtype} != {orig_sd[k].dtype}"
+        test_case.assertEqual(
+            v_info.size,
+            orig_info.size,
+            f"Sizes don't match for tensor {k}: {v_info.size} !="
+            f" {orig_info.size}",
+        )
 
-        assert torch.all(orig_sd[k].to(v.device) == v)
-        # fmt: on
-    del orig_model, orig_sd
+        test_case.assertEqual(
+            v_info.dtype,
+            orig_info.dtype,
+            f"dtypes don't match for tensor {k}: {v_info.dtype} !="
+            f" {orig_info.dtype}",
+        )
+
+        test_case.assertEqual(
+            v_info.hash,
+            orig_info.hash,
+            f"Contents don't match for tensor {k}",
+        )
+
+    del orig_sd
     gc.collect()
 
 
@@ -73,7 +136,10 @@ def enable_tokenizers_parallelism():
 
 
 def check_inference(
-    deserializer: TensorDeserializer, model_ref: str, device: str
+    test_case: unittest.TestCase,
+    deserializer: TensorDeserializer,
+    model_ref: str,
+    device: str,
 ):
     # This ensures that the model is not initialized.
     config = AutoConfig.from_pretrained(model_ref)
@@ -96,7 +162,7 @@ def check_inference(
             )
 
         decoded = tokenizer.decode(output[0], skip_special_tokens=True)
-        assert decoded.count("hello") > num_hellos
+        test_case.assertGreater(decoded.count("hello"), num_hellos)
 
 
 class TestSerialization(unittest.TestCase):
@@ -115,7 +181,7 @@ class TestSerialization(unittest.TestCase):
                 try:
                     with open(serialized_model, "rb") as in_file:
                         deserialized = TensorDeserializer(in_file, device="cpu")
-                        check_deserialized(deserialized, model_name)
+                        check_deserialized(self, deserialized, model_name)
                         deserialized.close()
                         del deserialized
                 finally:
@@ -142,7 +208,7 @@ class TestSerialization(unittest.TestCase):
         finally:
             os.unlink(tensorized_file.name)
 
-        assert torch.equal(tensor, deserialized_tensor)
+        self.assertTrue(torch.equal(tensor, deserialized_tensor))
 
 
 class TestDeserialization(unittest.TestCase):
@@ -165,7 +231,7 @@ class TestDeserialization(unittest.TestCase):
         before_deserialization = utils.get_mem_usage()
         deserialized = TensorDeserializer(in_file, device="cpu")
         after_deserialization = utils.get_mem_usage()
-        check_deserialized(deserialized, model_name)
+        check_deserialized(self, deserialized, model_name)
         deserialized.close()
         print(f"Before deserialization: {before_deserialization}")
         print(f"After deserialization:  {after_deserialization}")
@@ -176,7 +242,7 @@ class TestDeserialization(unittest.TestCase):
         gc.collect()
         before_deserialization = utils.get_mem_usage()
         deserialized = TensorDeserializer(in_file, device="cuda")
-        check_deserialized(deserialized, model_name)
+        check_deserialized(self, deserialized, model_name)
         after_deserialization = utils.get_mem_usage()
         deserialized.close()
         print(f"Before deserialization: {before_deserialization}")
@@ -192,8 +258,8 @@ class TestDeserialization(unittest.TestCase):
             in_file, device=default_device, lazy_load=True
         )
 
-        check_deserialized(deserialized, model_name)
-        check_inference(deserialized, model_name, default_device)
+        check_deserialized(self, deserialized, model_name)
+        check_inference(self, deserialized, model_name, default_device)
         deserialized.close()
 
     @unittest.skipIf(not is_cuda_available, "plaid_mode requires CUDA")
@@ -203,7 +269,7 @@ class TestDeserialization(unittest.TestCase):
             in_file, device="cuda", plaid_mode=True
         )
 
-        check_deserialized(deserialized, model_name)
+        check_deserialized(self, deserialized, model_name)
         deserialized.close()
 
     @unittest.skipIf(not is_cuda_available, "plaid_mode requires CUDA")
@@ -213,7 +279,7 @@ class TestDeserialization(unittest.TestCase):
             in_file, device="cuda", plaid_mode=True
         )
 
-        check_inference(deserialized, model_name, "cuda")
+        check_inference(self, deserialized, model_name, "cuda")
         deserialized.close()
 
     @unittest.skipIf(not is_cuda_available, "plaid_mode requires CUDA")
@@ -236,8 +302,8 @@ class TestDeserialization(unittest.TestCase):
         deserialized = TensorDeserializer(
             f"s3://tensorized/{model_name}/model.tensors", device=default_device
         )
-        check_deserialized(deserialized, model_name)
-        check_inference(deserialized, model_name, default_device)
+        check_deserialized(self, deserialized, model_name)
+        check_inference(self, deserialized, model_name, default_device)
         deserialized.close()
 
     @patch.object(stream_io, "_s3_default_config_paths", ())
@@ -246,10 +312,10 @@ class TestDeserialization(unittest.TestCase):
             f"s3://tensorized/{model_name}/fp16/model.tensors",
             device=default_device,
         )
-        assert deserialized.total_tensor_bytes > 0
+        self.assertGreater(deserialized.total_tensor_bytes, 0)
         if is_cuda_available and default_device != "cpu":
             # FP16 tensors don't work correctly on CPU in PyTorch
-            check_inference(deserialized, model_name, default_device)
+            check_inference(self, deserialized, model_name, default_device)
         deserialized.close()
 
     @patch.object(stream_io, "_s3_default_config_paths", ())
@@ -259,8 +325,8 @@ class TestDeserialization(unittest.TestCase):
             device=default_device,
             lazy_load=True,
         )
-        check_deserialized(deserialized, model_name)
-        check_inference(deserialized, model_name, default_device)
+        check_deserialized(self, deserialized, model_name)
+        check_inference(self, deserialized, model_name, default_device)
         deserialized.close()
 
     def test_filter_func(self):
@@ -276,30 +342,32 @@ class TestDeserialization(unittest.TestCase):
             in_file, device=default_device, filter_func=None
         )
         all_keys = set(deserialized.keys())
-        assert all_keys, (
+        self.assertTrue(
+            all_keys,
             "Deserializing the model with no filter_func"
-            " loaded an empty set of tensors"
+            " loaded an empty set of tensors",
         )
-        check_deserialized(deserialized, model_name)
+        check_deserialized(self, deserialized, model_name)
         deserialized.close()
 
         expected_regex_keys = set(filter(pattern.match, all_keys))
         expected_custom_keys = set(filter(custom_check, all_keys))
 
-        assert (
+        self.assertTrue(
             expected_regex_keys
             and expected_regex_keys < all_keys
             and expected_custom_keys
-            and expected_custom_keys < all_keys
-        ), (
-            "The filter_func test cannot continue"
-            " because a filter_func used in the test"
-            " does not appear in the test model,"
-            " or matches all tensor names."
-            " Update the pattern and/or custom_check"
-            " to use more informative filtering criteria."
-            "\n\nTensors present in the model: "
-            + " ".join(all_keys)
+            and expected_custom_keys < all_keys,
+            (
+                "The filter_func test cannot continue"
+                " because a filter_func used in the test"
+                " does not appear in the test model,"
+                " or matches all tensor names."
+                " Update the pattern and/or custom_check"
+                " to use more informative filtering criteria."
+                "\n\nTensors present in the model: "
+                + " ".join(all_keys)
+            ),
         )
 
         with self.subTest(msg="Testing regex filter_func"):
@@ -310,8 +378,10 @@ class TestDeserialization(unittest.TestCase):
             regex_keys = set(deserialized.keys())
             # Test that the deserialized tensors form a proper,
             # non-empty subset of the original list of tensors.
-            assert regex_keys == expected_regex_keys
-            check_deserialized(deserialized, model_name, allow_subset=True)
+            self.assertEqual(regex_keys, expected_regex_keys)
+            check_deserialized(
+                self, deserialized, model_name, allow_subset=True
+            )
             deserialized.close()
 
         with self.subTest(msg="Testing custom filter_func"):
@@ -320,79 +390,101 @@ class TestDeserialization(unittest.TestCase):
                 in_file, device=default_device, filter_func=custom_check
             )
             custom_keys = set(deserialized.keys())
-            assert custom_keys == expected_custom_keys
-            check_deserialized(deserialized, model_name, allow_subset=True)
+            self.assertEqual(custom_keys, expected_custom_keys)
+            check_deserialized(
+                self, deserialized, model_name, allow_subset=True
+            )
             deserialized.close()
 
 
+def mock_invalid_tensor_hash(*args, **kwargs):
+    tensor_hash = TensorHash(*args, **kwargs)
+    tensor_hash["hash"] = bytes(len(tensor_hash["hash"]))
+    return tensor_hash
+
+
 class TestVerification(unittest.TestCase):
+    _serialized_model_path: str
+
+    @classmethod
+    def setUpClass(cls):
+        serialized_model_path = serialize_model(model_name, "cpu")[0]
+        cls._serialized_model_path = serialized_model_path
+        gc.collect()
+
+    @classmethod
+    def tearDownClass(cls):
+        os.unlink(cls._serialized_model_path)
+
     def test_verification(self):
         for device in "cuda", "cpu":
             if device == "cuda" and not is_cuda_available:
                 continue
             with self.subTest(msg=f"Verifying hashes with device {device}"):
-                serialized_model, orig_sd = serialize_model(model_name, device)
-                del orig_sd
-                try:
-                    with open(serialized_model, "rb") as in_file:
-                        deserialized = TensorDeserializer(
+                with open(self._serialized_model_path, "rb") as in_file:
+                    deserialized = TensorDeserializer(
+                        in_file, device=device, verify_hash=True
+                    )
+                    check_deserialized(self, deserialized, model_name)
+                    deserialized.close()
+                    del deserialized
+
+    @patch.object(serialization, "TensorHash", mock_invalid_tensor_hash)
+    def test_verification_fail(self):
+        for device in "cuda", "cpu":
+            if device == "cuda" and not is_cuda_available:
+                continue
+            with self.subTest(msg=f"Verifying hashes with device {device}"):
+                with open(self._serialized_model_path, "rb") as in_file:
+                    with self.assertRaises(serialization.HashMismatchError):
+                        TensorDeserializer(
                             in_file, device=device, verify_hash=True
-                        )
-                        check_deserialized(deserialized, model_name)
-                        deserialized.close()
-                        del deserialized
-                finally:
-                    os.unlink(serialized_model)
+                        ).close()
 
     def test_module_verification(self):
+        model_to_verify = AutoModelForCausalLM.from_pretrained(model_name)
         for device in "cuda", "cpu":
             if device == "cuda" and not is_cuda_available:
                 continue
             with self.subTest(msg=f"Verifying hashes with device {device}"):
-                serialized_model, orig_sd = serialize_model(model_name, device)
-                del orig_sd
-                try:
-                    with open(serialized_model, "rb") as in_file:
-                        deserialized = TensorDeserializer(
-                            in_file, device=device
-                        )
-                        model_to_verify = AutoModelForCausalLM.from_pretrained(
-                            model_name
-                        ).to(device)
-                        result, tensor_status = deserialized.verify_module(
-                            model_to_verify
-                        )
-                        assert result
-                        for tensor_name, status in tensor_status:
-                            assert status, f"Tensor {tensor_name} failed"
-                        deserialized.close()
-                        del model_to_verify, deserialized
-                finally:
-                    os.unlink(serialized_model)
+                with open(self._serialized_model_path, "rb") as in_file:
+                    deserialized = TensorDeserializer(in_file, device=device)
+                    model_to_verify = model_to_verify.to(device)
+                    result, tensor_status = deserialized.verify_module(
+                        model_to_verify
+                    )
+                    deserialized.close()
+                    del deserialized
+                    self.assertTrue(result)
+                    for tensor_name, status in tensor_status:
+                        self.assertTrue(status, f"Tensor {tensor_name} failed")
 
     def test_module_verification_fail(self):
+        model_to_verify = AutoModelForCausalLM.from_pretrained(model_name)
         for device in "cuda", "cpu":
             if device == "cuda" and not is_cuda_available:
                 continue
             with self.subTest(msg=f"Verifying hashes with device {device}"):
-                serialized_model, orig_sd = serialize_model(model_name, device)
-                del orig_sd
-                try:
-                    with open(serialized_model, "rb") as in_file:
-                        deserialized = TensorDeserializer(
-                            in_file, device=device
-                        )
-                        model_to_verify = AutoModelForCausalLM.from_pretrained(
-                            model_name
-                        ).to(device)
-                        model_to_verify.transformer.h[0].ln_2 = (
-                            torch.nn.LayerNorm(768, 768)
-                        )
-                        result, tensor_status = deserialized.verify_module(
-                            model_to_verify
-                        )
-                        assert not result
-                        deserialized.close()
-                        del model_to_verify, deserialized
-                finally:
-                    os.unlink(serialized_model)
+                with open(self._serialized_model_path, "rb") as in_file:
+                    deserialized = TensorDeserializer(in_file, device=device)
+                    model_to_verify = model_to_verify.to(device)
+                    model_to_verify.transformer.h[0].ln_2 = torch.nn.LayerNorm(
+                        768, 768
+                    )
+                    result, tensor_status = deserialized.verify_module(
+                        model_to_verify
+                    )
+                    deserialized.close()
+                    del deserialized
+                    self.assertFalse(result, "Did not catch altered layer")
+                    for tensor_name, status in tensor_status:
+                        if tensor_name.startswith("transformer.h.0.ln_2"):
+                            self.assertFalse(
+                                status,
+                                f"Intended mismatch on {tensor_name} was"
+                                " not reported",
+                            )
+                        else:
+                            self.assertTrue(
+                                status, f"Unexpected mismatch on {tensor_name}"
+                            )

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -324,6 +324,7 @@ class TestDeserialization(unittest.TestCase):
             check_deserialized(deserialized, model_name, allow_subset=True)
             deserialized.close()
 
+
 class TestVerification(unittest.TestCase):
     def test_verification(self):
         for device in "cuda", "cpu":
@@ -334,9 +335,9 @@ class TestVerification(unittest.TestCase):
                 del orig_sd
                 try:
                     with open(serialized_model, "rb") as in_file:
-                        deserialized = TensorDeserializer(in_file,
-                                                          device=device,
-                                                          verify_hash=True)
+                        deserialized = TensorDeserializer(
+                            in_file, device=device, verify_hash=True
+                        )
                         check_deserialized(deserialized, model_name)
                         deserialized.close()
                         del deserialized
@@ -359,7 +360,8 @@ class TestVerification(unittest.TestCase):
                             model_name
                         ).to(device)
                         result, tensor_status = deserialized.verify_module(
-                            model_to_verify)
+                            model_to_verify
+                        )
                         assert result
                         for tensor_name, status in tensor_status:
                             assert status, f"Tensor {tensor_name} failed"
@@ -383,10 +385,12 @@ class TestVerification(unittest.TestCase):
                         model_to_verify = AutoModelForCausalLM.from_pretrained(
                             model_name
                         ).to(device)
-                        model_to_verify.transformer.h[0].ln_2 = \
+                        model_to_verify.transformer.h[0].ln_2 = (
                             torch.nn.LayerNorm(768, 768)
+                        )
                         result, tensor_status = deserialized.verify_module(
-                            model_to_verify)
+                            model_to_verify
+                        )
                         assert not result
                         deserialized.close()
                         del model_to_verify, deserialized


### PR DESCRIPTION
# Hash Verification Fixes & Polish
This PR contains fixes and updates for #34.

## Fixes
- Fixed `load_into_module` ignoring its `verify_hash` parameter
- Fixed a crash in `load_into_module` when a deserialized submodule is not present in the reference module
- Fixed a leaked `memoryview` on failed hash verification causing errors in `TensorDeserializer.close()` and `TensorDeserializer.__del__()`

## Tests:
- Added `test_verification_fail` to verify `verify_hash` failures outside of `TensorDeserializer.verify_module()`
- Added additional checks to `test_module_verification_fail` to ensure it caught the correct modified submodule
- Switched from `accel-object` to the `object` endpoint when reading from the `s3://tensorized` bucket during test cases
- Switched from `assert` statements to more descriptive `unittest.TestCase.assert*` methods
- Added clearer error messages for various test case failures
- Optimized speed of test cases
  - Deduplicated work serializing modules and loading reference models in `TestVerification`
  - Modified `check_deserialized()` to compare against cached hashes of reference models instead of reloading them on every call

## Docs
- Added missing docstring parameters and elaborated on existing ones
- Added `Args:` and `Returns:` blocks where missing
- Added `Raises:` blocks
- Simplified some type hints, corrected typos

## Misc.
- Restored `black` formatting
- Updated `black` version in pre-commit hooks
- Elided unnecessary tensor data copy in `verify_module()`
- Simplified and optimized handling of `bytes` objects in header parsing