### PR TITLE
fix: Add missing `verify_hash` parameter to `read_tensors()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `verify_hash` parameter for `TensorDeserializer.read_tensors`
   - Matches the one for `TensorDeserializer.read_numpy_arrays`
-  - Only to be used with lazy loading; has no effect on preloaded tensors
-    - Use `verify_hash` in the `TensorDeserializer` constructor if
-      not lazy-loading
 
 ## [2.1.0] - 2023-08-09
 
@@ -21,9 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Hash verification of deserialized models
   - During deserialization, specify `verify_hash=True` in either:
-    - The `TensorDeserializer` constructor, or:
-    - `TensorDeserializer.load_into_module` (during lazy loading), or
-    - `TensorDeserializer.read_numpy_arrays` (during lazy loading)
+    - The `TensorDeserializer` constructor,
+    - `TensorDeserializer.read_numpy_arrays`, or
+    - `TensorDeserializer.load_into_module` (only while lazy loading)
   - Comparing a model already in memory against its `.tensors` file:
     `TensorDeserializer.verify_module`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2023-08-10
+
+### Added
+
+- `verify_hash` parameter for `TensorDeserializer.read_tensors`
+  - Matches the one for `TensorDeserializer.read_numpy_arrays`
+  - Only to be used with lazy loading; has no effect on preloaded tensors
+    - Use `verify_hash` in the `TensorDeserializer` constructor if
+      not lazy-loading
+
 ## [2.1.0] - 2023-08-09
 
 ### Added
@@ -63,7 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Loading from public-read S3 buckets no longer requires blank credentials
-  to be explicitly specified via `stream_io.open_stream`.
+  to be explicitly specified via `stream_io.open_stream`
 
 ## [1.0.0] - 2023-03-21
 
@@ -82,6 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `get_gpu_name`
   - `no_init_or_tensor`
 
+[2.1.1]: https://github.com/coreweave/tensorizer/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/coreweave/tensorizer/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/coreweave/tensorizer/compare/v1.1.0...v2.0.0
 [1.1.0]: https://github.com/coreweave/tensorizer/compare/v1.0.1...v1.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorizer"
-version = "2.1.0"
+version = "2.1.1"
 license = { text = "MIT License" }
 keywords = ["tensorizer", "machine learning", "serialization", "tensor", "pytorch"]
 authors = [

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -1109,8 +1109,6 @@ class TensorDeserializer(collections.abc.Mapping):
                 this function prior to loading the tensors into a module.
                 If ``lazy_load=False``, this error case is impossible.
         """
-        # TODO: Account for the case where the module has more tensors than
-        #  what's serialized.
         modules: typing.OrderedDict[
             str, Union[torch.nn.Module, torch.Tensor]
         ] = OrderedDict()


### PR DESCRIPTION
# Hash Verification Control in `TensorDeserializer.read_tensors()`

This change adds a `verify_hash` parameter to `TensorDeserializer.read_tensors()` and bumps the code version to v2.1.1.

The nearly-identical function `TensorDeserializer.read_numpy_arrays()` had this parameter added in #34, and `read_tensors()` was intended to mirror that addition, but it was left out.