### PR TITLE
(feat)Add request header to `CURLStreamFile` along with additional metrics.

### DIFF
--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -442,11 +442,11 @@ class TensorDeserializer(collections.abc.Mapping):
     # If our _file object has 'response_headers' attribute, we can use it
     # to determine if we were cached or not.
     @property
-    def cache_status(self) -> Union[bool, str]:
+    def cache_status(self) -> Optional[str]:
         if hasattr(self._file, "response_headers"):
-            return self._file.response_headers.get("x-cache-status", False)
+            return self._file.response_headers.get("x-cache-status", None)
         else:
-            return False
+            return None
 
     def __getitem__(self, name) -> torch.nn.Parameter:
         if self._plaid_mode:

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -439,13 +439,12 @@ class TensorDeserializer(collections.abc.Mapping):
         else:
             return self._file.tell()
 
-    # If our _file object has 'response_headers' attribute, we can use it to
-    # to get the total size of the file, in addition to whether the object
-    # was cached.
+    # If our _file object has 'response_headers' attribute, we can use it
+    # to determine if we were cached or not.
     @property
-    def is_cached(self) -> bool:
+    def cache_status(self) -> Union[bool, str]:
         if hasattr(self._file, "response_headers"):
-            return self._file.response_headers.get("X-Cache-Status", "MISS") == "HIT"
+            return self._file.response_headers.get("X-Cache-Status", False)
         else:
             return False
 

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -444,7 +444,7 @@ class TensorDeserializer(collections.abc.Mapping):
     @property
     def cache_status(self) -> Union[bool, str]:
         if hasattr(self._file, "response_headers"):
-            return self._file.response_headers.get("X-Cache-Status", False)
+            return self._file.response_headers.get("x-cache-status", False)
         else:
             return False
 

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -432,10 +432,22 @@ class TensorDeserializer(collections.abc.Mapping):
 
     @property
     def total_bytes_read(self) -> int:
+        if hasattr(self._file, "bytes_read"):
+            return self._file.bytes_read
         if self._file.closed:
             return self.total_tensor_bytes
         else:
             return self._file.tell()
+
+    # If our _file object has 'response_headers' attribute, we can use it to
+    # to get the total size of the file, in addition to whether the object
+    # was cached.
+    @property
+    def is_cached(self) -> bool:
+        if hasattr(self._file, "response_headers"):
+            return self._file.response_headers.get("X-Cache-Status", "MISS") == "HIT"
+        else:
+            return False
 
     def __getitem__(self, name) -> torch.nn.Parameter:
         if self._plaid_mode:

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -202,7 +202,7 @@ class CURLStreamFile:
         self.popen_latencies.append(popen_end - popen_start)
         self.http_response_latencies.append(resp_begin - popen_end)
 
-        if not resp.startswith(b"HTTP/1.1 2") or not resp.startswith(b"HTTP/2 2"):
+        if not resp.contains(b"HTTP/1.1 2") and not resp.startswith(b"HTTP/2 2"):
             self._curl.terminate()
             self._curl.wait()
             raise IOError(f"Failed to open stream: {resp.decode('utf-8')}")

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -157,7 +157,7 @@ class CURLStreamFile:
             "--header",
             "Accept-Encoding: identity",
             "--dump-header",
-            "/dev/stderr",
+            "/dev/stderr", # TODO: Windows support, and maybe a temp pipe?
             "-A",
             _CURL_USER_AGENT,
             "-s",

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -202,7 +202,7 @@ class CURLStreamFile:
         self.popen_latencies.append(popen_end - popen_start)
         self.http_response_latencies.append(resp_begin - popen_end)
 
-        if not resp.startswith(b"HTTP/1.1 2"):
+        if not resp.startswith(b"HTTP/1.1 2") or not resp.startswith(b"HTTP/2 2"):
             self._curl.terminate()
             self._curl.wait()
             raise IOError(f"Failed to open stream: {resp.decode('utf-8')}")

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -205,12 +205,15 @@ class CURLStreamFile:
         # Read the rest of the header response and parse it.
         header_lines = self._curl.stderr.readlines()
         self.response_headers = {}
+        # FIXME: This should really be using the email.parser module, as there are
+        #        edge cases that this doesn't handle correctly, such as headers
+        #        with keys that are the same.
         for line in header_lines:
             line = line.decode("utf-8").strip()
             if not line or ':' not in line:
                 continue
             k, v = line.split(":", maxsplit=1)
-            self.response_headers[k.strip()] = v.strip()
+            self.response_headers[k.strip().lower()] = v.strip()
 
         self.error_buffer = ""
         self._curr = 0 if begin is None else begin

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -189,16 +189,9 @@ class CURLStreamFile:
 
         # We reinitialize this object when seeking, so we don't want to overwrite
         # these tracking variables if they already exist.
-        if not hasattr(self, "popen_latencies"):
-            self.popen_latencies: List[float] = []
-        if not hasattr(self, "http_response_latencies"):
-            self.http_response_latencies: List[float] = []
-        if not hasattr(self, "bytes_read"):
-            self.bytes_read: int = 0
-        if not hasattr(self, "bytes_skipped"):
-            self.bytes_skipped: int = 0
-        if not hasattr(self, "read_operations"):
-            self.read_operations: int = 0
+        self._init_vars()
+
+        # Track the latency of the popen and http response
         self.popen_latencies.append(popen_end - popen_start)
         self.http_response_latencies.append(resp_begin - popen_end)
 
@@ -214,7 +207,7 @@ class CURLStreamFile:
         self.response_headers = {}
         for line in header_lines:
             line = line.decode("utf-8").strip()
-            if not line:
+            if not line or ':' not in line:
                 continue
             k, v = line.split(":", maxsplit=1)
             self.response_headers[k.strip()] = v.strip()
@@ -223,6 +216,19 @@ class CURLStreamFile:
         self._curr = 0 if begin is None else begin
         self._end = end
         self.closed = False
+
+    def _init_vars(self):
+        if not hasattr(self, "popen_latencies"):
+            self.popen_latencies: List[float] = []
+        if not hasattr(self, "http_response_latencies"):
+            self.http_response_latencies: List[float] = []
+        if not hasattr(self, "bytes_read"):
+            self.bytes_read: int = 0
+        if not hasattr(self, "bytes_skipped"):
+            self.bytes_skipped: int = 0
+        if not hasattr(self, "read_operations"):
+            self.read_operations: int = 0
+
 
     def __enter__(self):
         return self

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -153,6 +153,7 @@ class CURLStreamFile:
             )
 
         header_r_pipe, header_w_pipe = os.pipe()
+        self._header_pipe = open(header_r_pipe, "rb")
         cmd = [
             curl_path,
             "--header",
@@ -186,7 +187,6 @@ class CURLStreamFile:
         popen_end = time.monotonic()
 
         _wide_pipes.widen_pipe(self._curl.stdout.fileno())  # Widen on Linux
-        self._header_pipe = open(header_r_pipe, "rb")
         resp = self._header_pipe.readline()  # Block on the http header response
         resp_begin = time.monotonic()
 

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -210,7 +210,6 @@ class CURLStreamFile:
         # noinspection PyTypeChecker
         self.response_headers = http.client.parse_headers(self._header_pipe)
 
-        self.error_buffer = ""
         self._curr = 0 if begin is None else begin
         self._end = end
         self.closed = False

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -202,7 +202,7 @@ class CURLStreamFile:
         self.popen_latencies.append(popen_end - popen_start)
         self.http_response_latencies.append(resp_begin - popen_end)
 
-        if not resp.contains(b"HTTP/1.1 2") and not resp.startswith(b"HTTP/2 2"):
+        if not resp.startswith(b"HTTP/1.1 2") and not resp.startswith(b"HTTP/2 2"):
             self._curl.terminate()
             self._curl.wait()
             raise IOError(f"Failed to open stream: {resp.decode('utf-8')}")


### PR DESCRIPTION
This adds response headers to the `CURLStreamFile `class by using curl's `--dump-header /dev/stderr` option, and reading from `stderr=subprocess.PIPE`. The bonus is that we can detect when we did not get a `HTTP 1.1 2*` response and handle it accordingly.

Also adds a few more tracking attributes:
* `popen_latencies`: A list of the time it took to start the cURL process.
* `http_response_latencies`: A list of the time it took to get the first HTTP response from the server.
* `response_headers`: A dictionary of the HTTP response headers.
* `bytes_read`: The number of bytes read from the stream.
* `bytes_skipped`: The number of bytes skipped from the stream.
* `read_operations`: The number of read operations performed on the stream.