### PR TITLE
refactor: Reorganize Deserialization Parsing

### DIFF
--- a/tensorizer/_version.py
+++ b/tensorizer/_version.py
@@ -1,1 +1,1 @@
-__version__ = "2.3.1.dev1"
+__version__ = "2.3.1.dev2"

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -869,6 +869,8 @@ class TensorDeserializer(collections.abc.Mapping):
         if hasattr(self._file, "bytes_read"):
             return self._file.bytes_read
         if self._file.closed:
+            # Caution: This case is an underestimate because it doesn't include
+            # any metadata read, unlike the other two cases.
             return self.total_tensor_bytes
         else:
             return self._file.tell()

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -407,7 +407,7 @@ class TestDeserialization(unittest.TestCase):
 
 def mock_invalid_tensor_hash(*args, **kwargs):
     tensor_hash = TensorHash(*args, **kwargs)
-    tensor_hash["hash"] = bytes(len(tensor_hash["hash"]))
+    tensor_hash.hash = bytes(len(tensor_hash.hash))
     return tensor_hash
 
 


### PR DESCRIPTION
# Deserialization Reorganization

This change groups encoding and decoding logic for header and metadata entries into dedicated classes, completely separate from the `TensorSerializer` and `TensorDeserializer` classes. `TensorSerializer` was already mostly updated to do this in #46, so this mainly affects `TensorDeserializer`.

This disentangles most of the *parsing* of `tensorizer`'s custom binary format from the *use* of that data, making it easier to update and optimize the deserializer's major bottlenecks like I/O, hash computation, and device transfer as was done in the serializer.