### PR TITLE
(feat)Add preliminary Redis support.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,5 +19,8 @@ jobs:
           python -m pip install -e . &&
           python -m pip install -r tests/requirements.txt
 
+      - name: Install Redis
+        run: sudo apt-get install -y redis-server
+
       - name: Run tests
         run: python -m unittest discover tests/ --verbose

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 Module, Model, and Tensor Serialization/Deserialization
 
 ## TLDR
-Extremely fast model loads from HTTP/HTTPS and S3 endpoints. GPT-J
-(`20GB`) loads at wire-speed (`~5GB/s`) on a 40GbE network, and is
-only bottlenecked by the Linux kernel TCP stack.
+Extremely fast model loads from HTTP/HTTPS, Redis, and S3 endpoints.
+GPT-J (`20GB`) loads at wire-speed (`~5GB/s`) on a 40GbE network, and
+is only bottlenecked by the Linux kernel TCP stack.
 
 ## Rationale
 CoreWeave and our customers use KNative to deploy models as serverless
@@ -35,6 +35,11 @@ pertains to HTTP/HTTPS endpoints, as S3 is just an HTTP/HTTPS endpoint.
 so you can use it to serialize models locally and load them locally. This
 is extremely fast, as the same principles that make it fast for HTTP/HTTPS
 and S3 endpoints also apply to local filesystems.
+
+`tensorizer` has preliminary support for Redis, but it is not recommended
+for model deployment due to the lack of distributed caching. It is intended
+for sharing state between inference pods, or for loading data on a per-request
+basis from a Redis cache.
 
 ## Installation
 
@@ -195,6 +200,12 @@ where `df_main()` serializes models from
 [HuggingFace Diffusers](https://github.com/huggingface/diffusers)
 and `hf_main()` serializes
 [HuggingFace Transformers](https://github.com/huggingface/transformers) models.
+
+## Benchmarks
+
+You can run your own benchmarks on CoreWeave or your own Kubernetes cluster
+by using the `benchmark.yaml` file in the `examples/benchmark_buffer_size`
+directory. Please see the [README](examples/benchmark_buffer_size/README.md).
 
 ## Available Pre-Tensorized Models on the CoreWeave Cloud
 

--- a/examples/benchmark_buffer_size/Dockerfile
+++ b/examples/benchmark_buffer_size/Dockerfile
@@ -1,5 +1,8 @@
 FROM ghcr.io/coreweave/ml-containers/torch:9faf4d7-base-cuda12.0.1-torch2.0.1-vision0.15.2-audio2.0.2
 
+RUN apt-get -qq update && \
+     apt-get install -y redis-server && \
+     apt-get clean
 RUN mkdir /app
 COPY tensorizer /app/tensorizer
 COPY requirements.txt /app/tensorizer

--- a/examples/benchmark_buffer_size/README.md
+++ b/examples/benchmark_buffer_size/README.md
@@ -40,7 +40,7 @@ If you want to test against an external Redis server, you can uncomment the
 Redis server in your namespace. You can install it by running `helm install
 redis-server redis-server.yaml`.
 
-If you want to test against a different model in the `tensorizer` bucket,
+If you want to test against a different model in the `tensorized` bucket,
 you can provide the `--model` flag. Please note that models larger than 2.7-3B
 require the container specs for GPUs to be increased to use a card with more
 than 8GB of memory.

--- a/examples/benchmark_buffer_size/README.md
+++ b/examples/benchmark_buffer_size/README.md
@@ -1,0 +1,50 @@
+Buffer Size Benchmarking Framework
+==================================
+This package contains a benchmarking framework for testing the performance of
+`tensorizer` with different transport layers and buffer sizes. Currently, the
+script tests the following:
+
+* `redis` transport layer using raw TCP socket (`RedisStreamFile`)
+* `https` transport layer using `curl` external process (`CURLStreamFile`)
+* `http` transport layer using `curl` external process (`CURLStreamFile`)
+* `s3` transport layer which computes authentication and uses `curl` external
+  process (`CURLStreamFile`)
+
+It iterates through different buffer sizes, the range given by `--begin` and 
+`--end` in powers of 2. For each buffer size, it runs the benchmark for all the
+transport layers.
+
+The `buffer_size` has different semantics depending on the transport layer. For
+Redis, it's the TCP socket buffer size. For `https`, `http`, and `s3`, it's the
+Python buffer size to the `curl` external process.
+
+By default, the `redis` tests are targeted to `localhost` on port `6379`. The
+pod definition automatically starts a Redis server on the same pod. We load the
+model into the Redis server from the `tensorizer` S3 bucket.
+
+Running the Benchmark
+---------------------
+You should be able to run the benchmark by invoking `kubectl apply -f benchmark.yaml`
+from this directory. This will start a Kubernetes Job that runs the benchmakr across
+10 pods. You can change the number of pods by changing the `parallelism` field in
+`benchmark.yaml`.
+
+To look at the benchmark results, you can run `kubectl logs -l job-name==tensorizer-benchmark-read-size`
+which will collect the logs from all the pods and print them out. You can also
+look at the logs for individual pods by running `kubectl logs <pod-name>`.
+
+Parameterizing the Benchmark
+----------------------------
+If you want to test against an external Redis server, you can uncomment the
+`--redis` line. We provide a Helm chart in `redis-server.yaml` to deploy a
+Redis server in your namespace. You can install it by running `helm install
+redis-server redis-server.yaml`.
+
+If you want to test against a different model in the `tensorizer` bucket,
+you can provide the `--model` flag. Please note that models larger than 2.7-3B
+require the container specs for GPUs to be increased to use a card with more
+than 8GB of memory.
+
+Depending on where you deploy your application, you may want to change the
+region affinity under `- key: topology.kubernetes.io/region`. This will
+ensure that the pods are scheduled in the same region as your application.

--- a/examples/benchmark_buffer_size/README.md
+++ b/examples/benchmark_buffer_size/README.md
@@ -29,7 +29,7 @@ from this directory. This will start a Kubernetes Job that runs the benchmark ac
 10 pods. You can change the number of pods by changing the `parallelism` field in
 `benchmark.yaml`.
 
-To look at the benchmark results, you can run `kubectl logs -l job-name==tensorizer-benchmark-read-size`
+To look at the benchmark results, you can run `kubectl logs --tail=-1 -l job-name==tensorizer-benchmark-read-size`
 which will collect the logs from all the pods and print them out. You can also
 look at the logs for individual pods by running `kubectl logs <pod-name>`.
 

--- a/examples/benchmark_buffer_size/README.md
+++ b/examples/benchmark_buffer_size/README.md
@@ -20,12 +20,12 @@ Python buffer size to the `curl` external process.
 
 By default, the `redis` tests are targeted to `localhost` on port `6379`. The
 pod definition automatically starts a Redis server on the same pod. We load the
-model into the Redis server from the `tensorizer` S3 bucket.
+model into the Redis server from the `tensorized` S3 bucket.
 
 Running the Benchmark
 ---------------------
 You should be able to run the benchmark by invoking `kubectl apply -f benchmark.yaml`
-from this directory. This will start a Kubernetes Job that runs the benchmakr across
+from this directory. This will start a Kubernetes Job that runs the benchmark across
 10 pods. You can change the number of pods by changing the `parallelism` field in
 `benchmark.yaml`.
 

--- a/examples/benchmark_buffer_size/benchmark.py
+++ b/examples/benchmark_buffer_size/benchmark.py
@@ -245,7 +245,7 @@ def bench_redis(
 
     del test_dict
 
-    if hasattr(torch, "cuda"):
+    if hasattr(torch, "cuda") and torch.cuda.is_available():
         torch.cuda.synchronize()
     gc.collect()
 

--- a/examples/benchmark_buffer_size/benchmark.py
+++ b/examples/benchmark_buffer_size/benchmark.py
@@ -141,12 +141,18 @@ def deserialize_test(
     plaid_mode=False,
     verify_hash=False,
     lazy_load=False,
+    force_http=False,
     buffer_size=256 * kibibyte,
 ):
     scheme = source.split("://")[0]
+    if scheme == "s3" and not force_http:
+        scheme = "s3s"
     scheme_pad = " " * (5 - len(scheme))
     source = open_stream(
-        source, s3_endpoint=default_s3_read_endpoint, buffer_size=buffer_size
+        source,
+        s3_endpoint=default_s3_read_endpoint,
+        buffer_size=buffer_size,
+        force_http=force_http,
     )
     start = time.monotonic()
     test_dict = TensorDeserializer(
@@ -324,4 +330,17 @@ for buffer_size_power in range(args.start, args.end):
         if has_gpu:
             deserialize_test(
                 source=s3_uri, buffer_size=buffer_size, plaid_mode=True
+            )
+        deserialize_test(
+            source=s3_uri,
+            buffer_size=buffer_size,
+            lazy_load=True,
+            force_http=True,
+        )
+        if has_gpu:
+            deserialize_test(
+                source=s3_uri,
+                buffer_size=buffer_size,
+                plaid_mode=True,
+                force_http=True,
             )

--- a/examples/benchmark_buffer_size/benchmark.py
+++ b/examples/benchmark_buffer_size/benchmark.py
@@ -326,4 +326,3 @@ for buffer_size_power in range(args.start, args.end):
                 source=s3_uri, buffer_size=buffer_size, plaid_mode=True
             )
 
-exit(0)

--- a/examples/benchmark_buffer_size/benchmark.py
+++ b/examples/benchmark_buffer_size/benchmark.py
@@ -172,6 +172,7 @@ def bench_redis(buffer_size=256 * kibibyte):
             f"redis://localhost:6379/{model_name}", buffer_size=buffer_size
         ),
         lazy_load=True,
+        plaid_mode=True,
     )
 
     all_begin = time.monotonic()
@@ -239,7 +240,10 @@ load_redis()
 for buffer_size_power in range(16, 21):
     buffer_size = 1 << buffer_size_power
     for sample in range(5):
+        io_test(buffer_size=buffer_size)
         io_test_redis(buffer_size=buffer_size)
         bench_redis(buffer_size=buffer_size)
+        deserialize_test(buffer_size=buffer_size)
+
 
 exit(0)

--- a/examples/benchmark_buffer_size/benchmark.py
+++ b/examples/benchmark_buffer_size/benchmark.py
@@ -188,7 +188,7 @@ def deserialize_test(
 def test_read_performance():
     # Test the speed of reading from a stream,
     # with different buffer sizes ranging from 128 KiB to 256 MiB.
-    for buffer_size_power in range(17, 28):
+    for buffer_size_power in range(args.start, args.end):
         buffer_size = 1 << buffer_size_power
         for sample in range(10):
             io_test(read_size=32 * kibibyte, buffer_size=buffer_size)

--- a/examples/benchmark_buffer_size/benchmark.py
+++ b/examples/benchmark_buffer_size/benchmark.py
@@ -18,7 +18,7 @@ logging.basicConfig(
 )
 
 # Read in model name from command line, or env var, or default to gpt-neo-2.7B
-model_name_default = os.getenv("MODEL_NAME") or "EleutherAI/gpt-j-6B/fp16"
+model_name_default = os.getenv("MODEL_NAME") or "EleutherAI/gpt-neo-2.7B/fp16"
 parser = argparse.ArgumentParser(
     description="Test CURLStreamFile download speeds"
 )
@@ -241,6 +241,5 @@ for buffer_size_power in range(16, 21):
     for sample in range(5):
         io_test_redis(buffer_size=buffer_size)
         bench_redis(buffer_size=buffer_size)
-
 
 exit(0)

--- a/examples/benchmark_buffer_size/benchmark.py
+++ b/examples/benchmark_buffer_size/benchmark.py
@@ -267,7 +267,7 @@ def io_test_redis(buffer_size=256 * kibibyte):
     for key in redis_client.scan_iter(f"{model_name}:*"):
         redis_tcp.send(f"GET {key.decode('utf-8')}\r\n".encode("utf-8"))
         # Loop over tcp bytes until we get a \r\n
-        sz_resp = b""
+        sz_resp = bytearray()
         while True:
             b = redis_tcp.recv(1)
             sz_resp += b

--- a/examples/benchmark_buffer_size/benchmark.py
+++ b/examples/benchmark_buffer_size/benchmark.py
@@ -180,7 +180,7 @@ def deserialize_test(
 
     test_dict.close()
     del test_dict
-    if hasattr(torch, "cuda"):
+    if hasattr(torch, "cuda") and torch.cuda.is_available():
         torch.cuda.synchronize()
     gc.collect()
 

--- a/examples/benchmark_buffer_size/benchmark.py
+++ b/examples/benchmark_buffer_size/benchmark.py
@@ -44,6 +44,18 @@ parser.add_argument(
     default=True,
     help="Whether to load the model into redis (default: True)",
 )
+parser.add_argument(
+    "--start",
+    type=int,
+    default=8,
+    help="Starting buffer size power (default: 8)",
+)
+parser.add_argument(
+    "--end",
+    type=int,
+    default=28,
+    help="Ending buffer size power (default: 28)",
+)
 args = parser.parse_args()
 
 model_name: str = args.model
@@ -277,7 +289,7 @@ def io_test_redis(buffer_size=256 * kibibyte):
 
 if args.load_redis:
     load_redis()
-for buffer_size_power in range(16, 21):
+for buffer_size_power in range(args.start, args.end):
     buffer_size = 1 << buffer_size_power
     for sample in range(5):
         io_test(buffer_size=buffer_size)

--- a/examples/benchmark_buffer_size/benchmark.py
+++ b/examples/benchmark_buffer_size/benchmark.py
@@ -44,11 +44,10 @@ parser.add_argument(
     help="Redis URI to use for testing (default: redis://localhost:6379)",
 )
 parser.add_argument(
-    "--load-redis",
-    type=bool,
-    action=argparse.BooleanOptionalAction,
-    default=True,
-    help="Whether to load the model into redis (default: True)",
+    "--no-load-redis",
+    action="store_true",
+    default=False,
+    help="Don't load the model into redis",
 )
 parser.add_argument(
     "--start",
@@ -301,7 +300,7 @@ def io_test_redis(buffer_size=256 * kibibyte):
     )
 
 
-if args.load_redis:
+if not args.no_load_redis:
     load_redis()
 for buffer_size_power in range(args.start, args.end):
     buffer_size = 1 << buffer_size_power

--- a/examples/benchmark_buffer_size/benchmark.py
+++ b/examples/benchmark_buffer_size/benchmark.py
@@ -69,7 +69,7 @@ http_uri = (
     "http://tensorized.accel-object.ord1.coreweave.com"
     f"/{model_name}/model.tensors"
 )
-
+https_uri = http_uri.replace("http://", "https://")
 s3_uri = f"s3://tensorized/{model_name}/model.tensors"
 
 # Get nodename from environment, or default to os.uname().nodename
@@ -126,7 +126,7 @@ def io_test(
 
     # Print the total size of the stream, and the speed at which it was read.
     logging.info(
-        f"{nodename} -- curl:  "
+        f"{nodename} -- http:  "
         f"gpu: {gpu_name} ({gpu_gb} GiB), raw read "
         f"{total_sz / mebibyte:0.2f} MiB at "
         f"{total_sz / mebibyte / (end - start):0.2f} MiB/s, "
@@ -306,16 +306,23 @@ for buffer_size_power in range(args.start, args.end):
     for sample in range(5):
         io_test(buffer_size=buffer_size)
         io_test_redis(buffer_size=buffer_size)
-        if has_gpu:
-            bench_redis(buffer_size=buffer_size, plaid_mode=True)
         bench_redis(buffer_size=buffer_size, lazy_load=True)
         if has_gpu:
-            deserialize_test(buffer_size=buffer_size, plaid_mode=True)
+            bench_redis(buffer_size=buffer_size, plaid_mode=True)
         deserialize_test(buffer_size=buffer_size, lazy_load=True)
+        if has_gpu:
+            deserialize_test(buffer_size=buffer_size, plaid_mode=True)
+        deserialize_test(
+            source=https_uri, buffer_size=buffer_size, lazy_load=True
+        )
+        if has_gpu:
+            deserialize_test(
+                source=https_uri, buffer_size=buffer_size, plaid_mode=True
+            )
+        deserialize_test(source=s3_uri, buffer_size=buffer_size, lazy_load=True)
         if has_gpu:
             deserialize_test(
                 source=s3_uri, buffer_size=buffer_size, plaid_mode=True
             )
-        deserialize_test(source=s3_uri, buffer_size=buffer_size)
 
 exit(0)

--- a/examples/benchmark_buffer_size/benchmark.py
+++ b/examples/benchmark_buffer_size/benchmark.py
@@ -312,7 +312,10 @@ for buffer_size_power in range(args.start, args.end):
         if has_gpu:
             deserialize_test(buffer_size=buffer_size, plaid_mode=True)
         deserialize_test(buffer_size=buffer_size, lazy_load=True)
+        if has_gpu:
+            deserialize_test(
+                source=s3_uri, buffer_size=buffer_size, plaid_mode=True
+            )
         deserialize_test(source=s3_uri, buffer_size=buffer_size)
-        deserialize_test(source=s3_uri, buffer_size=buffer_size, lazy_load=True)
 
 exit(0)

--- a/examples/benchmark_buffer_size/benchmark.py
+++ b/examples/benchmark_buffer_size/benchmark.py
@@ -44,8 +44,9 @@ parser.add_argument(
     help="Redis URI to use for testing (default: redis://localhost:6379)",
 )
 parser.add_argument(
-    "--load_redis",
+    "--load-redis",
     type=bool,
+    action=argparse.BooleanOptionalAction,
     default=True,
     help="Whether to load the model into redis (default: True)",
 )

--- a/examples/benchmark_buffer_size/benchmark.py
+++ b/examples/benchmark_buffer_size/benchmark.py
@@ -228,8 +228,9 @@ def bench_redis(
     )
 
     start = time.monotonic()
-    for name in test_dict:
-        test_dict[name]
+    if lazy_load or plaid_mode:
+        for name in test_dict:
+            test_dict[name]
     end = time.monotonic()
     total_sz = test_dict.total_bytes_read
 
@@ -325,4 +326,3 @@ for buffer_size_power in range(args.start, args.end):
             deserialize_test(
                 source=s3_uri, buffer_size=buffer_size, plaid_mode=True
             )
-

--- a/examples/benchmark_buffer_size/benchmark.py
+++ b/examples/benchmark_buffer_size/benchmark.py
@@ -86,7 +86,7 @@ gibibyte = 1 << 30
 # Collect GPU data
 try:
     cudadev = torch.cuda.current_device()
-    gpu_gb = int(torch.cuda.get_device_properties(0).total_memory / gibibyte)
+    gpu_gb = torch.cuda.get_device_properties(0).total_memory // gibibyte
     gpu_name = torch.cuda.get_device_name(cudadev)
     has_gpu = True
 except AssertionError:

--- a/examples/benchmark_buffer_size/benchmark.yaml
+++ b/examples/benchmark_buffer_size/benchmark.yaml
@@ -28,4 +28,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-      restartPolicy: Always
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              job-name: tensorizer-benchmark-read-size
+      restartPolicy: OnFailure

--- a/examples/benchmark_buffer_size/benchmark.yaml
+++ b/examples/benchmark_buffer_size/benchmark.yaml
@@ -7,12 +7,28 @@ spec:
   completions: 100
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: ethernet.coreweave.cloud/speed
+                operator: In
+                values:
+                   - 10G
+                   - 40G
+                   - 100G
+              - key: topology.kubernetes.io/region
+                operator: In
+                values:
+                - LGA1
       containers:
         - name: benchmark
-          image: ghcr.io/coreweave/tensorizer:benchmark-78ed8fe
+          image: ghcr.io/coreweave/tensorizer:benchmark-8e85696
           imagePullPolicy: IfNotPresent
           command: [ "/bin/bash" ]
-          args: [ "-c", "redis-server --daemonize yes & python /app/benchmark.py" ]
+          args: [ "-c", "redis-server --daemonize yes >/dev/null & python /app/benchmark.py" ]
+          #--redis redis://redis-master:6379" ]
           resources:
             requests:
               cpu: "8"

--- a/examples/benchmark_buffer_size/benchmark.yaml
+++ b/examples/benchmark_buffer_size/benchmark.yaml
@@ -11,15 +11,16 @@ spec:
         - name: benchmark
           image: ghcr.io/coreweave/tensorizer:benchmark-5dda83c
           imagePullPolicy: IfNotPresent
-          command: [ "python", "/app/benchmark.py" ]
+          command: [ "/bin/bash" ]
+          args: [ "-c" "redis-server && python /app/benchmark.py" ]
           resources:
             requests:
-              cpu: "4"
-              memory: 32Gi
+              cpu: "8"
+              memory: 64Gi
               nvidia.com/gpu: "1"
             limits:
-              cpu: "4"
-              memory: 32Gi
+              cpu: "8"
+              memory: 64Gi
               nvidia.com/gpu: "1"
           env:
             - name: PYTHONUNBUFFERED

--- a/examples/benchmark_buffer_size/benchmark.yaml
+++ b/examples/benchmark_buffer_size/benchmark.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       containers:
         - name: benchmark
-          image: ghcr.io/coreweave/tensorizer:benchmark-da4e2dd
+          image: ghcr.io/coreweave/tensorizer:benchmark-78ed8fe
           imagePullPolicy: IfNotPresent
           command: [ "/bin/bash" ]
           args: [ "-c", "redis-server --daemonize yes & python /app/benchmark.py" ]

--- a/examples/benchmark_buffer_size/benchmark.yaml
+++ b/examples/benchmark_buffer_size/benchmark.yaml
@@ -9,10 +9,10 @@ spec:
     spec:
       containers:
         - name: benchmark
-          image: ghcr.io/coreweave/tensorizer:benchmark-ddf4b3f
+          image: ghcr.io/coreweave/tensorizer:benchmark-da4e2dd
           imagePullPolicy: IfNotPresent
           command: [ "/bin/bash" ]
-          args: [ "-c" "redis-server && python /app/benchmark.py" ]
+          args: [ "-c", "redis-server --daemonize yes & python /app/benchmark.py" ]
           resources:
             requests:
               cpu: "8"

--- a/examples/benchmark_buffer_size/benchmark.yaml
+++ b/examples/benchmark_buffer_size/benchmark.yaml
@@ -26,7 +26,7 @@ spec:
                 - ORD1
       containers:
         - name: benchmark
-          image: ghcr.io/coreweave/tensorizer:benchmark-9821ae3
+          image: ghcr.io/coreweave/tensorizer:benchmark-fe3982d
           imagePullPolicy: IfNotPresent
           command: [ "/bin/bash" ]
           args: [ "-c", "redis-server --daemonize yes >/dev/null & python /app/benchmark.py" ]

--- a/examples/benchmark_buffer_size/benchmark.yaml
+++ b/examples/benchmark_buffer_size/benchmark.yaml
@@ -15,16 +15,18 @@ spec:
               - key: ethernet.coreweave.cloud/speed
                 operator: In
                 values:
-                   - 10G
+                   #- 10G
                    - 40G
                    - 100G
               - key: topology.kubernetes.io/region
                 operator: In
                 values:
                 - LGA1
+                - LAS1
+                - ORD1
       containers:
         - name: benchmark
-          image: ghcr.io/coreweave/tensorizer:benchmark-8e85696
+          image: ghcr.io/coreweave/tensorizer:benchmark-9821ae3
           imagePullPolicy: IfNotPresent
           command: [ "/bin/bash" ]
           args: [ "-c", "redis-server --daemonize yes >/dev/null & python /app/benchmark.py" ]

--- a/examples/benchmark_buffer_size/benchmark.yaml
+++ b/examples/benchmark_buffer_size/benchmark.yaml
@@ -26,7 +26,7 @@ spec:
                 - ORD1
       containers:
         - name: benchmark
-          image: ghcr.io/coreweave/tensorizer:benchmark-fe3982d
+          image: ghcr.io/coreweave/tensorizer:benchmark-2a3aa4f
           imagePullPolicy: IfNotPresent
           command: [ "/bin/bash" ]
           args: [ "-c", "redis-server --daemonize yes >/dev/null & python /app/benchmark.py" ]

--- a/examples/benchmark_buffer_size/benchmark.yaml
+++ b/examples/benchmark_buffer_size/benchmark.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       containers:
         - name: benchmark
-          image: ghcr.io/coreweave/tensorizer:benchmark-5dda83c
+          image: ghcr.io/coreweave/tensorizer:benchmark-ddf4b3f
           imagePullPolicy: IfNotPresent
           command: [ "/bin/bash" ]
           args: [ "-c" "redis-server && python /app/benchmark.py" ]

--- a/examples/benchmark_buffer_size/benchmark.yaml
+++ b/examples/benchmark_buffer_size/benchmark.yaml
@@ -26,7 +26,7 @@ spec:
                 - ORD1
       containers:
         - name: benchmark
-          image: ghcr.io/coreweave/tensorizer:benchmark-2a3aa4f
+          image: ghcr.io/coreweave/tensorizer:benchmark-e03ab78
           imagePullPolicy: IfNotPresent
           command: [ "/bin/bash" ]
           args: [ "-c", "redis-server --daemonize yes >/dev/null & python /app/benchmark.py" ]

--- a/examples/benchmark_buffer_size/redis-server.yaml
+++ b/examples/benchmark_buffer_size/redis-server.yaml
@@ -19,7 +19,7 @@ master: &sharedConfig
     limits:
       cpu: "4"
       memory: 49Gi
-  # Persistence volume claim
+  # Persistent volume claim
   persistence:
     storageClass: block-hdd-ord1
 

--- a/examples/benchmark_buffer_size/redis-server.yaml
+++ b/examples/benchmark_buffer_size/redis-server.yaml
@@ -1,0 +1,42 @@
+# Master pod spec
+master: &sharedConfig
+  # Only use nodes from ORD1
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: topology.kubernetes.io/region
+            operator: In
+            values:
+              - ORD1
+          - key: ethernet.coreweave.cloud/speed
+            operator: In
+            values:
+              - 40G
+  # Set limits
+  resources:
+    limits:
+      cpu: "4"
+      memory: 49Gi
+  # Persistence volume claim
+  persistence:
+    storageClass: block-hdd-ord1
+
+# Replica pod spec
+replica: *sharedConfig
+
+# Disable replication for now
+# TODO: Move to Redis Sentinel
+architecture: standalone
+
+# Set redis config
+commonConfiguration: |
+  maxmemory 32768mb
+  maxmemory-policy allkeys-lru
+  appendonly no
+  save ""
+
+# Disable password auth
+auth:
+  enabled: false

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -2,4 +2,3 @@ transformers~=4.27.1
 diffusers==0.14.0
 scipy~=1.10.0
 accelerate==0.17.1
-redis

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -2,3 +2,4 @@ transformers~=4.27.1
 diffusers==0.14.0
 scipy~=1.10.0
 accelerate==0.17.1
+redis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,9 @@ dependencies = [
     "numpy>=1.19.5",
     "protobuf>=3.19.5",
     "psutil>=5.9.4",
-    "boto3>=1.26.0"
+    "boto3>=1.26.0",
+    "redis>=5.0.0",
+    "hiredis>=2.2.0"
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy>=1.19.5
 protobuf>=3.19.5
 psutil>=5.9.4
 boto3>=1.26.0
+hiredis

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ protobuf>=3.19.5
 psutil>=5.9.4
 boto3>=1.26.0
 hiredis
+redis==5.0.0

--- a/tensorizer/_wide_pipes.py
+++ b/tensorizer/_wide_pipes.py
@@ -99,7 +99,7 @@ if sys.platform != "win32":
         pipe_buf_sz = get_max_pipe_size()
         try:
             fcntl.fcntl(fileno, F_SETPIPE_SZ, pipe_buf_sz)
-        except (PermissionError, OSError) as e:
+        except OSError as e:
             _logger.warning(
                 f"Couldn't fcntl F_SETPIPE_SZ to {pipe_buf_sz}: {e.strerror}"
             )

--- a/tensorizer/_wide_pipes.py
+++ b/tensorizer/_wide_pipes.py
@@ -99,7 +99,7 @@ if sys.platform != "win32":
         pipe_buf_sz = get_max_pipe_size()
         try:
             fcntl.fcntl(fileno, F_SETPIPE_SZ, pipe_buf_sz)
-        except PermissionError as e:
+        except (PermissionError, OSError) as e:
             _logger.warning(
                 f"Couldn't fcntl F_SETPIPE_SZ to {pipe_buf_sz}: {e.strerror}"
             )

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -531,7 +531,7 @@ class _MetadataDeserializer(dict):
     @classmethod
     def from_io(
         cls, reader: io.BufferedIOBase, count: int
-    ) -> ("_MetadataDeserializer", bytes):
+    ) -> Tuple["_MetadataDeserializer", bytes]:
         raw = reader.read(cls._total_len_segment.size)
         total_len: int = cls._total_len_segment.unpack(raw)[0]
         if total_len == 0:

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -1519,10 +1519,6 @@ class TensorDeserializer(collections.abc.Mapping):
             # convert to ms
             duration_ms = (end - start) * 1000
             rate = (header_size + len(data_entry)) / (end - start) / 1024 / 1024
-            print(
-                f"Redis write for {name} took {duration_ms:0.2f}ms @"
-                f" {rate:0.2f}MB/s"
-            )
 
 
 class TensorSerializer:

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -1499,6 +1499,11 @@ class TensorDeserializer(collections.abc.Mapping):
         """
         Given a redis client and a key_prefix, write the tensors in this
         Tensorizer object to the redis client under the given key prefixes.
+
+        Args:
+            redis_client: A redis client to write the tensors to.
+            key_prefix: A key prefix to use for the tensors.
+            force: If True, overwrite existing keys in redis.
         """
         header_entry = b"|TZR|"
         header_entry += self._file_header.to_bytes()

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -36,6 +36,7 @@ from typing import (
 )
 
 import numpy
+import redis
 import torch
 
 import tensorizer.stream_io as stream_io
@@ -530,15 +531,15 @@ class _MetadataDeserializer(dict):
     @classmethod
     def from_io(
         cls, reader: io.BufferedIOBase, count: int
-    ) -> "_MetadataDeserializer":
-        total_len: int = cls._total_len_segment.unpack(
-            reader.read(cls._total_len_segment.size)
-        )[0]
+    ) -> ("_MetadataDeserializer", bytes):
+        raw = reader.read(cls._total_len_segment.size)
+        total_len: int = cls._total_len_segment.unpack(raw)[0]
         if total_len == 0:
-            return cls()
+            return cls(), raw
         else:
             encoded_metadata: bytes = reader.read(total_len)
-            return cls.from_buffer(encoded_metadata, count)
+            raw += encoded_metadata
+            return cls.from_buffer(encoded_metadata, count), raw
 
     @classmethod
     def from_buffer(cls, buffer: bytes, count: int) -> "_MetadataDeserializer":
@@ -724,7 +725,7 @@ class TensorDeserializer(collections.abc.Mapping):
             raise ValueError("Not a tensorizer file")
 
         # Read the file header
-        file_header = _FileHeader.from_io(
+        self._file_header = _FileHeader.from_io(
             self._file,
             accepted_versions=(
                 NON_OPAQUE_TENSORIZER_VERSION,
@@ -737,12 +738,12 @@ class TensorDeserializer(collections.abc.Mapping):
         # deserializer, but has been available as a public attribute,
         # so it is kept how it was for compatibility until the next
         # major version.
-        self.total_file_bytes = file_header.tensor_size
+        self.total_file_bytes = self._file_header.tensor_size
 
         # Read the metadata index of tensors. This is a list of offsets into the
         # file where the per-tensor data is stored.
-        self._metadata = _MetadataDeserializer.from_io(
-            self._file, file_header.tensor_count
+        self._metadata, self._metadata_raw = _MetadataDeserializer.from_io(
+            self._file, self._file_header.tensor_count
         )
         # filter_func is a test that determines the tensor names to read.
         # If filter_func is None, all tensors are read.
@@ -1009,7 +1010,8 @@ class TensorDeserializer(collections.abc.Mapping):
         filter_func: Optional[Callable[[str], Union[bool, Any]]] = None,
         num_tensors: int = -1,
         verify_hash: Optional[bool] = None,
-    ) -> Iterator[Tuple[int, int, str, _NumpyTensor]]:
+        raw: bool = False,
+    ) -> Iterator[Tuple[int, int, str, Union[_NumpyTensor, memoryview]]]:
         """
         A generator that deserializes tensors and returns the `module_idx`,
         `tensor_type`, parameter/buffer `name`, and a _NumpyTensor `tensor`.
@@ -1121,12 +1123,15 @@ class TensorDeserializer(collections.abc.Mapping):
                         mv.release()
                         raise
 
-                tensor = _NumpyTensor.from_buffer(
-                    numpy_dtype,
-                    torch_dtype,
-                    header.shape,
-                    mv,
-                )
+                if raw:
+                    tensor = mv
+                else:
+                    tensor = _NumpyTensor.from_buffer(
+                        numpy_dtype,
+                        torch_dtype,
+                        header.shape,
+                        mv,
+                    )
 
                 tensors_read += 1
 
@@ -1487,6 +1492,37 @@ class TensorDeserializer(collections.abc.Mapping):
             results.append((name, False))
 
         return all(result for name, result in results), results
+
+    def to_redis(self, redis_client: redis.Redis, key_prefix: str) -> None:
+        """
+        Given a redis client and a key_prefix, write the tensors in this
+        Tensorizer object to the redis client under the given key prefixes.
+        """
+        metadata_size = 256 * 1024
+        header_entry = b"|TZR|"
+        header_entry += self._file_header.to_bytes()
+        header_entry += self._metadata_raw
+        redis_client.set(f"{key_prefix}:header:0", header_entry)
+
+        for name in self._metadata:
+            entry = self._metadata[name]
+            start = time.monotonic()
+            offset = self._metadata[name].offset
+            data_offset = self._metadata[name].data_offset
+            header_size = data_offset - offset
+            self._file.seek(offset)
+            header_entry = self._file.read(header_size)
+            redis_client.set(f"{key_prefix}:{name}:{offset}", header_entry)
+            data_entry = self._file.read(entry.data_length)
+            redis_client.set(f"{key_prefix}:{name}:{data_offset}", data_entry)
+            end = time.monotonic()
+            # convert to ms
+            duration_ms = (end - start) * 1000
+            rate = (header_size + len(data_entry)) / (end - start) / 1024 / 1024
+            print(
+                f"Redis write for {name} took {duration_ms:0.2f}ms @"
+                f" {rate:0.2f}MB/s"
+            )
 
 
 class TensorSerializer:

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -665,7 +665,7 @@ class TensorDeserializer(collections.abc.Mapping):
             deserializer = TensorDeserializer(s3, plaid_mode=True)
             deserializer.load_into_module(model)
 
-        .. _pre-serialized: https://github.com/coreweave/tensorizer/tree/main#available-pre-tensorized-models-on-the-coreweave-cloud
+        ... _pre-serialized: https://github.com/coreweave/tensorizer/tree/main#available-pre-tensorized-models-on-the-coreweave-cloud
     """
 
     def __init__(
@@ -1353,9 +1353,6 @@ class TensorDeserializer(collections.abc.Mapping):
 
         Args:
             m: The module to load the tensors into.
-            device: The device to load the tensors onto.
-            dtype: The dtype to load the tensors as. Defaults to None, which
-                means the dtype is not changed from the serialized dtype.
             filter_func: A function (tensor_name: str) -> bool that returns
                 True if a tensor should be loaded, or False if it should be
                 skipped.

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -615,7 +615,7 @@ class RedisStreamFile:
 
     def _read_sz(self) -> int:
         # Loop until we get a \r\n
-        sz_resp = b""
+        sz_resp = bytearray()
         while True:
             b = self._redis_tcp.recv(1)
             sz_resp += b

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -835,6 +835,7 @@ def s3_download(
     s3_secret_access_key: str,
     s3_endpoint: str = default_s3_read_endpoint,
     buffer_size: Optional[int] = None,
+    force_http: bool = False,
 ) -> CURLStreamFile:
     url = _s3_download_url(
         path_uri=path_uri,
@@ -842,6 +843,8 @@ def s3_download(
         s3_secret_access_key=s3_secret_access_key,
         s3_endpoint=s3_endpoint,
     )
+    if force_http:
+        url = url.replace("https://", "http://")
     return CURLStreamFile(url, buffer_size=buffer_size)
 
 
@@ -992,6 +995,7 @@ def open_stream(
     s3_endpoint: Optional[str] = None,
     s3_config_path: Optional[Union[str, bytes, os.PathLike]] = None,
     buffer_size: Optional[int] = None,
+    force_http: bool = False,
 ) -> Union[CURLStreamFile, RedisStreamFile, typing.BinaryIO]:
     """
     Open a file path, http(s):// URL, or s3:// URI.
@@ -1030,6 +1034,9 @@ def open_stream(
             to be parsed if full credentials are not provided.
             If None, platform-specific default paths are used.
         buffer_size: The size of the TCP or pipe buffer to use.
+        force_http: If True, force the use of HTTP instead of HTTPS for
+            S3 downloads. This will double the throughput, but at the cost
+            of security.
 
     Returns:
         An opened file-like object representing the target resource.
@@ -1162,6 +1169,7 @@ def open_stream(
                 s3_secret_access_key,
                 s3_endpoint,
                 buffer_size=buffer_size,
+                force_http=force_http,
             )
             if error_context:
                 curl_stream_file.register_error_context(error_context)

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -654,8 +654,6 @@ class RedisStreamFile:
                 return orig_mv.tobytes()
             else:
                 return rq_sz - left
-        except (IOError, OSError) as e:
-            raise e
 
     def tell(self) -> int:
         return self._curr

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -618,6 +618,8 @@ class RedisStreamFile:
         sz_resp = bytearray()
         while True:
             b = self._redis_tcp.recv(1)
+            if b == b"":
+                raise IOError("Failed to read size")
             sz_resp += b
             if sz_resp[-2:] == b"\r\n":
                 break

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -469,6 +469,7 @@ class RedisStreamFile:
         buffer_size: The size of the TCP buffer to use for the Redis connection.
 
     Attributes:
+        setup_latency: The time it took to setup the Redis connections and enumerate.
         response_latencies: A list of the time it took to get the Redis responses.
         bytes_read: The number of bytes read from the stream.
         bytes_skipped: The number of bytes skipped from the stream.
@@ -481,6 +482,7 @@ class RedisStreamFile:
         *,
         buffer_size: int = _MAX_TCP_BUFFER_SIZE,
     ) -> None:
+        init_begin = time.monotonic()
         host, port, prefix = _parse_redis_uri(uri)
         self._redis = redis.Redis(host=host, port=port, db=0)
         self._redis_tcp = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -517,6 +519,9 @@ class RedisStreamFile:
         self._curr_buffer_view = memoryview(self._curr_buffer)[0:0]
         self.closed = False
 
+        init_end = time.monotonic()
+
+        self.setup_latency = init_end - init_begin
         self.response_latencies = []
         self.bytes_read = 0
         self.bytes_skipped = 0

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -23,7 +23,7 @@ import redis
 import tensorizer._version as _version
 import tensorizer._wide_pipes as _wide_pipes
 
-__all__ = ["open_stream", "CURLStreamFile"]
+__all__ = ["open_stream", "CURLStreamFile", "RedisStreamFile"]
 
 logger = logging.getLogger(__name__)
 

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -607,7 +607,8 @@ class RedisStreamFile:
             self._curr_buffer_idx = position + num_bytes
 
         # Read the trailing \r\n and discard.
-        self._redis_tcp.recv(2)
+        if self._redis_tcp.recv(2) != b"\r\n":
+            raise RuntimeError("Missing key footer")
 
         self._redis_tcp_mutex.release()
         return num_bytes

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -146,7 +146,7 @@ class CURLStreamFile:
         end: Optional[int] = None,
         headers: Dict[str, Any] = None,
         *,
-        buffer_size: Optional[int],
+        buffer_size: Optional[int] = None,
     ) -> None:
         if buffer_size is None:
             buffer_size = 2 << 20
@@ -482,7 +482,7 @@ class RedisStreamFile:
         self,
         uri: str,
         *,
-        buffer_size: Optional[int],
+        buffer_size: Optional[int] = None,
     ) -> None:
         if buffer_size is None:
             buffer_size = _MAX_TCP_BUFFER_SIZE

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -439,9 +439,9 @@ def _parse_redis_uri(uri):
 
 # Detect if we're running on OSX, and if so, set max buffer size to 1 MiB.
 if sys.platform == "darwin":
-    _MAX_TCP_BUFFER_SIZE = 2 << 20  # 1 MiB if OSX
+    _MAX_TCP_BUFFER_SIZE = 1 << 20  # 1 MiB if OSX
 else:
-    _MAX_TCP_BUFFER_SIZE = 2 << 22  # 8 MiB
+    _MAX_TCP_BUFFER_SIZE = 8 << 20  # 8 MiB
 
 
 class RedisStreamFile:

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -146,7 +146,7 @@ class CURLStreamFile:
         end: Optional[int] = None,
         headers: Dict[str, Any] = None,
         *,
-        buffer_size: int = 2 << 20,  # 2 MiB buffer on the Python IO object
+        buffer_size: Optional[int],
     ) -> None:
         if buffer_size is None:
             buffer_size = 2 << 20
@@ -482,7 +482,7 @@ class RedisStreamFile:
         self,
         uri: str,
         *,
-        buffer_size: int = _MAX_TCP_BUFFER_SIZE,
+        buffer_size: Optional[int],
     ) -> None:
         if buffer_size is None:
             buffer_size = _MAX_TCP_BUFFER_SIZE

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -426,7 +426,7 @@ def _parse_redis_uri(uri):
     uri_components = urlparse(uri)
 
     if uri_components.scheme.lower() != "redis":
-        raise ValueError(f"Invalid S3 URI: {uri}")
+        raise ValueError(f"Invalid Redis URI: {uri}")
 
     host = uri_components.hostname
     port = uri_components.port

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -497,15 +497,13 @@ class RedisStreamFile:
         self._redis_tcp_mutex = threading.Lock()
 
         # Do a key scan for the prefix, and collect all the indexes from the keys.
-        self._keys = []
         self._indexes = []
         self._sizes = []
         keys = self._redis.scan_iter(f"{prefix}:*")
         # Sort the keys by their index.
-        for key in sorted(
+        self._keys = sorted(
             keys, key=lambda x: int(x.decode("utf-8").split(":")[-1])
-        ):
-            self._keys.append(key)
+        )
 
         # Get indexes.
         largest = 0

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -149,7 +149,7 @@ class CURLStreamFile:
         buffer_size: Optional[int] = None,
     ) -> None:
         if buffer_size is None:
-            buffer_size = 2 << 20
+            buffer_size = 2 << 23  # 16mb
         self._uri = uri
         self._error_context = []
 

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -444,7 +444,7 @@ class RedisStreamFile:
         self,
         uri: str,
         *,
-        buffer_size: int = 2 << 20,
+        buffer_size: int = 2 << 22,  # 8mb buffer on TCP socket
     ) -> None:
         host, port, prefix = _parse_redis_uri(uri)
         self._redis = redis.Redis(host=host, port=port, db=0)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,2 @@
 transformers>=4.27.1
 moto[s3,server]>=4.1.4
-redis>=5.0.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,4 @@
 transformers>=4.27.1
 moto[s3,server]>=4.1.4
+redis>=5.0.0
+hiredis>=2.2.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
 transformers>=4.27.1
 moto[s3,server]>=4.1.4
+redis>=5.0.0

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -28,6 +28,7 @@ from tensorizer import (
     utils,
 )
 from tensorizer.serialization import TensorHash, TensorType
+from test_stream_io import TestRedis
 
 model_name = "EleutherAI/gpt-neo-125M"
 num_hellos = 400
@@ -336,6 +337,47 @@ class TestDeserialization(unittest.TestCase):
         check_deserialized(self, deserialized, model_name)
         check_inference(self, deserialized, model_name, default_device)
         deserialized.close()
+
+    def test_redis(self):
+        test_redis = TestRedis()
+        test_redis.setUpClass()
+        test_redis.setUp()
+        redis_model_path = (
+            f"redis://{test_redis.redis_host}:{test_redis.redis_port}"
+            f"/{model_name}"
+        )
+
+        deserialized_s3 = TensorDeserializer(
+            f"s3://tensorized/{model_name}/model.tensors",
+            device=default_device,
+        )
+        deserialized_s3.to_redis(test_redis.redis_client, model_name)
+        deserialized_s3.close()
+
+        with self.subTest(msg="Testing redis deserialization in eager mode"):
+            deserialized_redis = TensorDeserializer(
+                redis_model_path,
+                device=default_device,
+            )
+            check_deserialized(self, deserialized_redis, model_name)
+            check_inference(
+                self, deserialized_redis, model_name, default_device
+            )
+            deserialized_redis.close()
+
+        with self.subTest(msg="Testing redis deserialization in lazy mode"):
+            deserialized_redis = TensorDeserializer(
+                redis_model_path,
+                device=default_device,
+                lazy_load=True,
+            )
+            check_deserialized(self, deserialized_redis, model_name)
+            check_inference(
+                self, deserialized_redis, model_name, default_device
+            )
+            deserialized_redis.close()
+
+        test_redis.tearDown()
 
     def test_filter_func(self):
         # These two filters should produce identical results

--- a/tests/test_stream_io.py
+++ b/tests/test_stream_io.py
@@ -147,11 +147,10 @@ class TestRedis(unittest.TestCase):
         cls.hello_k = "t:hello:0"
         cls.world_k = f"t:world:{len(cls.hello_str)}"
         cls.ex_k = f"t:excl:{len(cls.hello_str) + len(cls.world_str)}"
-        cls.keys = [cls.hello_k, cls.world_k, cls.ex_k]
 
     @classmethod
     def tearDown(cls):
-        cls.redis_client.delete(*cls.keys)
+        cls.redis_client.flushall()
         cls.redis_client.close()
         cls.redis.kill()
         cls.redis.wait()
@@ -179,6 +178,8 @@ class TestRedis(unittest.TestCase):
                 output += line
                 time_limit -= 1
             else:
+                # Log the output in case of failure
+                print(output)
                 raise Exception("Redis server did not start")
 
         # Populate redis with data
@@ -189,7 +190,7 @@ class TestRedis(unittest.TestCase):
         cls.redis_client.set(cls.world_k, cls.world_str)
         cls.redis_client.set(cls.ex_k, cls.ex_str)
 
-    def test_download(self):
+    def test_redis_stream(self):
         with stream_io.open_stream(
             f"redis://{self.redis_host}:{self.redis_port}/t",
             mode="rb",

--- a/tests/test_stream_io.py
+++ b/tests/test_stream_io.py
@@ -154,6 +154,7 @@ class TestRedis(unittest.TestCase):
         cls.redis_client.delete(*cls.keys)
         cls.redis_client.close()
         cls.redis.kill()
+        cls.redis.wait()
 
     @classmethod
     def setUp(cls):

--- a/tests/test_stream_io.py
+++ b/tests/test_stream_io.py
@@ -225,6 +225,13 @@ class TestRedis(unittest.TestCase):
                     ),
                     self.hello_str + self.world_str + self.ex_str,
                 )
+            # Report on our latencies
+            setup_latency_ms = s.setup_latency * 1000
+            response_latencies = ", ".join(
+                [f"{r * 1000:0.2f}ms" for r in s.response_latencies]
+            )
+            print(f"Redis setup latency: {setup_latency_ms:0.2f}ms")
+            print(f"Redis response latencies: {response_latencies}")
 
 
 class TestS3(unittest.TestCase):

--- a/tests/test_stream_io.py
+++ b/tests/test_stream_io.py
@@ -152,6 +152,7 @@ class TestRedis(unittest.TestCase):
     def tearDown(cls):
         cls.redis_client.flushall()
         cls.redis_client.close()
+        cls.redis.stdout.close()
         cls.redis.kill()
         cls.redis.wait()
 

--- a/tests/test_stream_io.py
+++ b/tests/test_stream_io.py
@@ -169,7 +169,7 @@ class TestRedis(unittest.TestCase):
         # Read output until ready
         output = b""
         time_limit = 5
-        while b"Ready to accept connections" not in output and not time_limit:
+        while b"Ready to accept connections" not in output and time_limit > 0:
             poll_result = select.select(
                 [self.redis.stdout], [], [], time_limit
             )[0]


### PR DESCRIPTION
This is a preliminary implementation of Redis support by implementing a `RedisStreamFile` class.

```
    RedisStreamFile implements a file-like object around a Redis key namespace. Each
    'file' is broken up into multiple keys, each of which is a slice of the file. Each
    key is named with the prefix, followed by a colon, a user-assigned name, another
    colon, and then the byte index of the key.

    For example, if the prefix is 'foo', and the user-assigned name is 'bar', then the
    keys would be 'foo:bar:0', 'foo:bar:16'. The first key would be the first 16 bytes
    of the file, and the remainder would be in the next key.

    On initialization, it performs a prefix scan of the keys for the prefix, and then
    sorts the keys by their byte index. This allows it to perform a seek operation
    efficiently, as it can find the key that contains the byte index, and then read
    from that key.

    RedisStreamFile has some optimizations, such as reading the entirety of a key into
    a buffer, and then serving subsequent reads from that buffer. It also has a buffer
    for the remainder of a key, so that it can serve partial reads of a key.

    Arguments:
        uri: The URI of the Redis key namespace. This should be prefixed by the
            'redis://' scheme, and include the key prefix. For example,
            'redis://localhost:6379/foo'.
        buffer_size: The size of the TCP buffer to use for the Redis connection.

    Attributes:
        response_latencies: A list of the time it took to get the Redis responses.
        bytes_read: The number of bytes read from the stream.
        bytes_skipped: The number of bytes skipped from the stream.
        read_operations: The number of read operations performed on the stream.
```

The `TensorizerDeserializer` object has a new method, `to_redis()` that will populate a Redis server with tensors. For each file, it:
* Creates a key for the file metadata
... then it iterates over the tensors, creating two keys:
* Tensor metadata
* Tensor data



It's pretty quick, but this Redis support is still preliminary as it hasn't shown itself to give enough value vs just using S3. The trouble is going to be distributing enough instances and being semi-rack local.

The use cases I had in mind for this was for:
* Loading LoRAs on a per-request basis for inference
* kv cache between inference instances

```
2023-10-03 15:17:50 INFO     g32f8f4 -- curl:  gpu: NVIDIA RTX A6000 (47 GiB), raw read 5430.50 MiB at 1001.08 MiB/s, 8192.0 KiB stream buffer size, 256.0 KiB read size, cached: HIT by lga1-7d9984f84d-ntg55
2023-10-03 15:17:54 INFO     g32f8f4 -- redis: gpu: NVIDIA RTX A6000 (47 GiB), raw read 5430.66 MiB at 1594.09 MiB/s, 8192.0 KiB stream buffer size
2023-10-03 15:17:57 INFO     g32f8f4 -- redis: gpu: NVIDIA RTX A6000 (47 GiB), loaded   5430.66 MiB at 1532.85 MiB/s, 8192.0 KiB stream buffer size, plaid: True, verify_hash: False, lazy_load: True
2023-10-03 15:18:03 INFO     g32f8f4 -- redis: gpu: NVIDIA RTX A6000 (47 GiB), loaded   5430.66 MiB at 1109.77 MiB/s, 8192.0 KiB stream buffer size, plaid: False, verify_hash: False, lazy_load: True
2023-10-03 15:18:09 INFO     g32f8f4 -- curl:  gpu: NVIDIA RTX A6000 (47 GiB), loaded   5430.66 MiB at 848.45 MiB/s, 8192.0 KiB stream buffer size, plaid: True, verify_hash: False, lazy_load: True, cached: HIT by lga1-7d9984f84d-cghv5
2023-10-03 15:18:18 INFO     g32f8f4 -- curl:  gpu: NVIDIA RTX A6000 (47 GiB), loaded   5430.66 MiB at 632.85 MiB/s, 8192.0 KiB stream buffer size, plaid: False, verify_hash: False, lazy_load: True, cached: HIT by lga1-7d9984f84d-ntg55
```

~~**NOTE:** I am not sure why the test cases are failing on GHA, it appears that it can't reach `localhost`?~~ Solved.
