### PR TITLE
Allow insecure curl downloads with CURLStreamFile

### DIFF
--- a/tests/test_stream_io.py
+++ b/tests/test_stream_io.py
@@ -370,3 +370,23 @@ class TestS3(unittest.TestCase):
                 s3_endpoint=endpoint,
             ) as s:
                 self.assertEqual(s.read(), long_string)
+
+    @patch.object(stream_io, "_s3_default_config_paths", ())
+    def test_download_insecure(self):
+        # Same as TestS3.test_download but with an insecure CURLStreamFile.
+        # Doesn't do anything here since the mock endpoint is http anyway
+        # and _ensure_https_endpoint() is disabled.
+        with mock_server() as endpoint:
+            key = "model.tensors"
+            long_string = b"Hello" * 1024
+            self.put_bucket_contents(key, long_string)
+            self.assert_bucket_contents(key, long_string)
+            with stream_io.open_stream(
+                f"s3://{self.BUCKET_NAME}/{key}",
+                mode="rb",
+                s3_access_key_id="X",
+                s3_secret_access_key="X",
+                s3_endpoint=endpoint,
+                allow_insecure=True,
+            ) as s:
+                self.assertEqual(s.read(), long_string)


### PR DESCRIPTION
- Useful for HTTPS links with self-signed certificates. 
- #58 


### Usage
Say, you bringup up a local [minio](https://github.com/minio/minio) S3 endpoint with self-signed certificates (created using [certgen](https://github.com/minio/certgen)).

```bash
podman run -p 9000:9000 -p 9001:9001 -v $HOME/.minio:/root/.minio -v $HOME/work/bucket:/data quay.io/minio/minio server /data --console-address ":9001"
```

You can get a file stream with `stream_io.open_stream` with the `allow_insecure` flag enabled. Which can then be passed onto `TensorDeserializer`.
```python
stream = stream_io.open_stream("s3://model.tensor",
                               mode="rb",
                               s3_access_key_id='minioadmin',
                               s3_secret_access_key='minioadmin',
                               s3_endpoint='https://127.0.0.1:9000',
                               allow_insecure=True)
```

Without the `allow_insecure` flag, the call will raise an error.
```python
stream = stream_io.open_stream("s3://model.tensor",
                               mode="rb",
                               s3_access_key_id='minioadmin',
                               s3_secret_access_key='minioadmin',
                               s3_endpoint='https://127.0.0.1:9000')

# OSError: Failed to open stream
```