### PR TITLE
feat: Expose cURL's `--cacert` and `--capath`, along with `--insecure`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Customization is achieved by passing an instance of `stream_io.CAInfo`
     to `open_stream` or the `CURLStreamFile` constructor
   - Example usages:
-    - `open_stream("https://localhost/model.tensors`, certificate_handling=CAInfo(cacert="./localhost.pem")`
-    - `open_stream("https://127.0.0.1/model.tensors`, certificate_handling=CAInfo(allow_untrusted=True)`
+    - `open_stream("https://localhost/model.tensors", certificate_handling=CAInfo(cacert="./localhost.pem")`
+    - `open_stream("https://127.0.0.1/model.tensors", certificate_handling=CAInfo(allow_untrusted=True)`
   - Pass `certificate_handling=None` (the default) to use default certificate
     verification as compiled into cURL
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     buffers
   - The default (`include_non_persistent_buffers=True`) matches the old
     behaviour
+- `stream_io.open_stream` and `stream_io.CURLStreamFile` now accept an
+  additional, optional `certificate_handling` argument to customize
+  the verification of SSL certificates
+  - This corresponds to the flags
+    [`--cacert`](https://curl.se/docs/manpage.html#--cacert),
+    [`--capath`](https://curl.se/docs/manpage.html#--capath), and
+    [`-k`/`--insecure`](https://curl.se/docs/manpage.html#-k) in `curl`
+  - Customization is achieved by passing an instance of `stream_io.CAInfo`
+    to `open_stream` or the `CURLStreamFile` constructor
+  - Example usages:
+    - `open_stream("https://localhost/model.tensors`, certificate_handling=CAInfo(cacert="./localhost.pem")`
+    - `open_stream("https://127.0.0.1/model.tensors`, certificate_handling=CAInfo(allow_untrusted=True)`
+  - Pass `certificate_handling=None` (the default) to use default certificate
+    verification as compiled into cURL
 
 ## [2.5.1] - 2023-10-17
 

--- a/tensorizer/_version.py
+++ b/tensorizer/_version.py
@@ -1,1 +1,1 @@
-__version__ = "2.6.0.dev0"
+__version__ = "2.6.0.dev1"

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -292,7 +292,6 @@ class CURLStreamFile:
             if not explanation:
                 # Otherwise, check if cURL gave a meaningful exit code
                 return_code: Optional[int] = self._curl.poll()
-                print("Return code:", return_code)
                 if isinstance(return_code, int) and return_code != 0:
                     explanation = (
                         f": cURL exit code {return_code:d};"

--- a/tests/test_stream_io.py
+++ b/tests/test_stream_io.py
@@ -370,3 +370,23 @@ class TestS3(unittest.TestCase):
                 s3_endpoint=endpoint,
             ) as s:
                 self.assertEqual(s.read(), long_string)
+
+    @patch.object(stream_io, "_s3_default_config_paths", ())
+    def test_download_insecure(self):
+        # Same as TestS3.test_download but with an insecure CURLStreamFile.
+        # Doesn't do anything here since the mock endpoint is http anyway
+        # and _ensure_https_endpoint() is disabled.
+        with mock_server() as endpoint:
+            key = "model.tensors"
+            long_string = b"Hello" * 1024
+            self.put_bucket_contents(key, long_string)
+            self.assert_bucket_contents(key, long_string)
+            with stream_io.open_stream(
+                f"s3://{self.BUCKET_NAME}/{key}",
+                mode="rb",
+                s3_access_key_id="X",
+                s3_secret_access_key="X",
+                s3_endpoint=endpoint,
+                allow_insecure=True,
+            ) as s:
+                self.assertEqual(s.read(), long_string)

--- a/tests/test_stream_io.py
+++ b/tests/test_stream_io.py
@@ -387,6 +387,6 @@ class TestS3(unittest.TestCase):
                 s3_access_key_id="X",
                 s3_secret_access_key="X",
                 s3_endpoint=endpoint,
-                allow_insecure=True,
+                allow_untrusted_certificate=True,
             ) as s:
                 self.assertEqual(s.read(), long_string)


### PR DESCRIPTION
# Customizing cURL Certificate Verification

This PR builds off of #59 by @spmkone and closes #58.

## Additions
- `stream_io.open_stream` and `stream_io.CURLStreamFile` now accept an additional, optional `certificate_handling` argument to customize the verification of SSL certificates
  - This corresponds to the flags [`--cacert`](https://curl.se/docs/manpage.html#--cacert), [`--capath`](https://curl.se/docs/manpage.html#--capath), and [`-k`/`--insecure`](https://curl.se/docs/manpage.html#-k) in `curl`
  - Customization is achieved by passing an instance of `stream_io.CAInfo` to `open_stream` or the `CURLStreamFile` constructor
  - Example usages:
    - `open_stream("https://localhost/model.tensors", certificate_handling=CAInfo(cacert="./localhost.pem")`
    - `open_stream("https://127.0.0.1/model.tensors", certificate_handling=CAInfo(allow_untrusted=True)`
  - Pass `certificate_handling=None` (the default) to use default certificate verification as compiled into cURL

## Changes from #59
- This adds more secure alternatives to `--insecure` when using self-signed certificates, to encourage better security practices
- `allow_insecure` has been removed as a direct parameter to `open_stream` and friends, and is instead a `CAInfo` option
- Test cases cover using customized `CAInfo` configurations with self-signed certificates in `moto`
- Fixed a bug where only S3 and not raw HTTPS downloads were using `open_stream`'s certificate verification configuration

## Bonus
Error messages in the `CURLStreamFile` constructor have been improved in the case where cURL terminates at startup with no other output (e.g. when SSL certificate verification fails) by querying the subprocess exit code and attaching it as supplementary information, if it is nonzero.