### PR TITLE
feat(crypto): Initial pass at crypto implementation.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ dependencies = [
     "psutil>=5.9.4",
     "boto3>=1.26.0",
     "redis>=5.0.0",
-    "hiredis>=2.2.0"
+    "hiredis>=2.2.0",
+    "pynacl>=1.5.0",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -205,9 +205,7 @@ class DecryptedStream(io.RawIOBase):
         self._lockbox = nacl.secret.SecretBox(key)
         self._nonce_int = int.from_bytes(nonce, "big", signed=False)
         self._chunk_size = chunk_size
-        self._ciphertext_chunk_sz = (
-            chunk_size + self._lockbox.MACBYTES + self._lockbox.NONCE_SIZE
-        )
+        self._ciphertext_chunk_sz = chunk_size + self._lockbox.MACBYTES
         self._ciphertext_buffer = bytearray(self._ciphertext_chunk_sz)
 
     def __enter__(self):
@@ -233,9 +231,7 @@ class DecryptedStream(io.RawIOBase):
         num_chunks = goal // self._chunk_size
         if goal % self._chunk_size:
             num_chunks += 1
-        ciphertext_goal = goal + (
-            num_chunks * (self._lockbox.MACBYTES + self._lockbox.NONCE_SIZE)
-        )
+        ciphertext_goal = goal + (num_chunks * self._lockbox.MACBYTES)
 
         step = 0
         while ciphertext_offset < ciphertext_goal:
@@ -260,6 +256,7 @@ class DecryptedStream(io.RawIOBase):
             ba[plaintext_offset : plaintext_offset + plaintext_sz] = (
                 self._lockbox.decrypt(ciphertext, step_nonce_bytes)
             )
+            step += 1
             ciphertext_offset += ciphertext_read_sz
             plaintext_offset += plaintext_sz
 

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -18,6 +18,7 @@ from urllib.parse import urlparse
 
 import boto3
 import botocore
+import nacl.secret
 import redis
 
 import tensorizer._version as _version
@@ -186,7 +187,108 @@ class CAInfo:
         return hash(self._curl_flags)
 
 
-class CURLStreamFile:
+class DecryptedStream(io.RawIOBase):
+    """
+    This class is a file-like object that wraps a mixed stream of encrypted and
+    decrypted data. It is intended to be called when it is known that the next
+    read is going to be a decryption operation.
+    """
+
+    def __init__(
+        self,
+        stream: io.RawIOBase,
+        key: bytes,
+        nonce: bytes,
+        chunk_size: int = 1024 << 8,
+    ):
+        self._stream = stream
+        self._lockbox = nacl.secret.SecretBox(key)
+        self._nonce_int = int.from_bytes(nonce, "big", signed=False)
+        self._chunk_size = chunk_size
+        self._ciphertext_chunk_sz = (
+            chunk_size + self._lockbox.MACBYTES + self._lockbox.NONCE_SIZE
+        )
+        self._ciphertext_buffer = bytearray(self._ciphertext_chunk_sz)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def __del__(self):
+        self.close()
+
+    def tell(self) -> int:
+        return self._stream.tell()
+
+    def readinto(self, ba: bytearray) -> int:
+        goal = len(ba)
+        if goal == 0:
+            return 0
+        # Read in chunks of self._chunk_size and decrypt them into ba
+        # until we have enough bytes.
+        ciphertext_offset = 0
+        plaintext_offset = 0
+        num_chunks = goal // self._chunk_size
+        if goal % self._chunk_size:
+            num_chunks += 1
+        ciphertext_goal = goal + (
+            num_chunks * (self._lockbox.MACBYTES + self._lockbox.NONCE_SIZE)
+        )
+
+        step = 0
+        while ciphertext_offset < ciphertext_goal:
+            step_nonce = self._nonce_int ^ step
+            step_nonce_bytes = step_nonce.to_bytes(
+                nacl.secret.SecretBox.NONCE_SIZE, "big", signed=False
+            )
+            if ciphertext_offset + self._ciphertext_chunk_sz > ciphertext_goal:
+                ciphertext_read_sz = ciphertext_goal - ciphertext_offset
+                ciphertext = memoryview(self._ciphertext_buffer)[
+                    :ciphertext_read_sz
+                ]
+            else:
+                ciphertext_read_sz = self._ciphertext_chunk_sz
+                ciphertext = self._ciphertext_buffer
+            if ciphertext_read_sz == 0:
+                break
+            plaintext_sz = self._chunk_size
+            if goal - plaintext_offset < plaintext_sz:
+                plaintext_sz = goal - plaintext_offset
+            self._stream.readinto(ciphertext)
+            ba[plaintext_offset : plaintext_offset + plaintext_sz] = (
+                self._lockbox.decrypt(ciphertext, step_nonce_bytes)
+            )
+            ciphertext_offset += ciphertext_read_sz
+            plaintext_offset += plaintext_sz
+
+    def read(self, size=-1) -> bytes:
+        buf = bytearray(size)
+        bytes_read = self.readinto(buf)
+        return bytes(buf[:bytes_read])
+
+    def writable(self) -> bool:
+        return False
+
+    def fileno(self) -> int:
+        return self._stream.fileno()
+
+    def close(self):
+        # We are a passive wrapper, so we don't close the underlying stream.
+        pass
+
+    def closed(self):
+        return self._stream.closed
+
+    def readline(self, size=-1) -> bytes:
+        return self._stream.readline(size)
+
+    def seek(self, position, whence=SEEK_SET):
+        self._stream.seek(position, whence)
+
+
+class CURLStreamFile(io.RawIOBase):
     """
     CURLStreamFile implements a file-like object around an HTTP download, the
     intention being to not buffer more than we have to. It is intended for
@@ -307,7 +409,7 @@ class CURLStreamFile:
 
         self._curr = 0 if begin is None else begin
         self._end = end
-        self.closed = False
+        self._closed = False
 
     def _init_vars(self):
         self.popen_latencies: List[float] = getattr(self, "popen_latencies", [])
@@ -444,7 +546,7 @@ class CURLStreamFile:
                     ret_buff = ba
             self.bytes_read += ret_buff_sz
             if ret_buff_sz != rq_sz:
-                self.closed = True
+                self._closed = True
                 self._curl.terminate()
                 raise IOError(f"Requested {rq_sz} != {ret_buff_sz}")
             self._curr += ret_buff_sz
@@ -464,23 +566,21 @@ class CURLStreamFile:
         return self._read_until(goal_position, ba)
 
     def read(self, size=None) -> bytes:
-        if self.closed:
+        if self._closed:
             raise IOError("CURLStreamFile closed.")
         if size is None:
             return self._curl.stdout.read()
         goal_position = self._curr + size
         return self._read_until(goal_position)
 
-    @staticmethod
-    def writable() -> bool:
+    def writable(self) -> bool:
         return False
 
-    @staticmethod
-    def fileno() -> int:
+    def fileno(self) -> int:
         return -1
 
     def close(self):
-        self.closed = True
+        self._closed = True
         if self._curl is not None:
             if self._curl.poll() is None:
                 self._curl.stdout.close()
@@ -492,7 +592,10 @@ class CURLStreamFile:
                 self._curl.stdout.close()
             self._curl = None
 
-    def readline(self):
+    def closed(self):
+        return self._closed
+
+    def readline(self, size=-1) -> bytes:
         raise NotImplementedError("Unimplemented")
 
     """


### PR DESCRIPTION
Tensor encryption and decryption.

Some design decisions and notes:
- We only encrypt the actual tensor payload itself. This helps us avoid a format change. There's a case to encrypting the metadata header as well, but that requires a format change so I'm punting that.
- We leverage the existing hash fields to contain the salt, nonce, and block_size for each tensor.
- Encryption is easy. Just provide passphrase= argument to the Deserializer and Serializer.
- We follow good practices, such as: random nonce's, ensuring that there's a new nonce each and every time, salting the passphrase with a random salt.
- By design, we don't encrypt the entire tensor payload in one go -- instead we use a streaming block cipher, xsalsa20 with poly HMAC -- this allows us to decrypt concurrently with reads rather than waiting for the entire thing.