### PR TITLE
fix: Correct tensor size calculation in TensorSerializer

### DIFF
--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -2557,7 +2557,7 @@ class TensorSerializer:
         fallocate = getattr(os, "posix_fallocate", None)
         if fallocate and self._fd:
             size = sum(len(t.name) for t in tensors)
-            size += sum(t.tensor.untyped_storage().size() for t in tensors)
+            size += sum(t.tensor.element_size() * t.tensor.nelement() for t in tensors)
             # Rough underestimate of header size
             header_min_size = 24
             size += header_min_size * len(tensors)


### PR DESCRIPTION
This PR replaces the original tensor size calculation for bulk writing which summed the sizes of each tensor's `UntypedStorage` size with an approach that calculates the tensor size based off of the number of elements and the size of each elements.

The issue that the original tensor size calculation prevented was that it did not account for views or shared storages. For example, Megatron has a `main_grad` tensor in each parameter which is a view from a larger buffer where all of the `main_grad` objects share the same storage object. With the previous method on a 6B model, the original size calculation returns ~6GiB for each `main_grad` tensor despite the actual tensor being a fraction of the size. In the end, it attempted to write 1.3TiB of data for all of the `main_grad` tensors.

The new method ensures that the tensor size is calculated based from the actual number of elements (`tensor.nelement()`) multiplied against the size of each element (`tensor.element_size()`) which skirts around the overallocation issue by calculating tensor size from a storage that could have been potentially shared.