### PR TITLE
fix(examples): Miscellaneous `hf_serialization.py` fixes

### DIFF
--- a/examples/hf_serialization.py
+++ b/examples/hf_serialization.py
@@ -65,7 +65,7 @@ logger.addHandler(fh)
 def check_file_exists(file: str):
     """
     Check if file exists and is not empty. If the file is found locally,
-    it is checked for emptiness with `os.path.exists`. If the file is found
+    it is checked for emptiness with `os.stat`. If the file is found
     on S3, it is checked for emptiness by reading the first byte of the file.
 
     Args:
@@ -75,7 +75,8 @@ def check_file_exists(file: str):
     try:
         return os.stat(file).st_size > 0
     except FileNotFoundError:
-        if not file.lower().startswith("s3://"):
+        uri = file.lower()
+        if not any(map(uri.startswith, ("s3://", "http://", "https://"))):
             return False
         try:
             with _read_stream(file) as f:

--- a/examples/hf_serialization.py
+++ b/examples/hf_serialization.py
@@ -164,7 +164,7 @@ def load_model(
     if model_prefix is None:
         model_prefix = "model"
 
-    begin_load = time.time()
+    begin_load = time.perf_counter()
     ram_usage = utils.get_mem_usage()
 
     config_uri = f"{path_uri}/{model_prefix}-config.json"
@@ -199,7 +199,7 @@ def load_model(
         tensor_stream, device=device, dtype=dtype, lazy_load=True
     ) as tensor_deserializer:
         tensor_deserializer.load_into_module(model)
-        tensor_load_s = time.time() - begin_load
+        tensor_load_s = time.perf_counter() - begin_load
         bytes_read: int = tensor_deserializer.total_bytes_read
 
     rate_str = utils.convert_bytes(bytes_read / tensor_load_s)

--- a/examples/hf_serialization.py
+++ b/examples/hf_serialization.py
@@ -292,7 +292,7 @@ def hf_main(args):
     logger.info("GPU: " + utils.get_gpu_name())
     logger.info("PYTHON USED RAM: " + utils.get_mem_usage())
 
-    serialize_model(model, model_config, output_prefix, None, args.force)
+    serialize_model(model, model_config, output_prefix, force=args.force)
 
     if args.validate:
         # Not sure if this part is needed as, although I doubt it,

--- a/examples/hf_serialization.py
+++ b/examples/hf_serialization.py
@@ -72,9 +72,11 @@ def check_file_exists(file: str):
         file: The path to check for existence and emptiness. This can
            either be a local path or an S3 URI.
     """
-    if os.path.exists(file):
-        return True
-    else:
+    try:
+        return os.stat(file).st_size > 0
+    except FileNotFoundError:
+        if not file.lower().startswith("s3://"):
+            return False
         try:
             with _read_stream(file) as f:
                 return bool(f.read(1))

--- a/examples/hf_serialization.py
+++ b/examples/hf_serialization.py
@@ -123,7 +123,7 @@ def serialize_model(
                 config_dict = (
                     config.to_dict() if hasattr(config, "to_dict") else config
                 )
-                f.write(json.dumps(config_dict).encode("utf-8"))
+                f.write(json.dumps(config_dict, indent=2).encode("utf-8"))
 
     if (not weights_file_exists) or force:
         logger.info(f"Writing tensors to {dir_prefix}.tensors")

--- a/examples/hf_serialization.py
+++ b/examples/hf_serialization.py
@@ -196,7 +196,7 @@ def load_model(
             model = model_class(**config)
 
     with _read_stream(tensors_uri) as tensor_stream, TensorDeserializer(
-        tensor_stream, device=device, dtype=dtype, lazy_load=True
+        tensor_stream, device=device, dtype=dtype
     ) as tensor_deserializer:
         tensor_deserializer.load_into_module(model)
         tensor_load_s = time.perf_counter() - begin_load


### PR DESCRIPTION
# `hf_serialization.py` Fixes

Miscellaneous fixes and improvements for #73.

- Fixes calling `serialize_model` with a default `model_prefix`
- Fixes indentation for saved config files
- Fixes checking local files for emptiness
- Doesn't use `lazy_load=True` when it's not helpful
- Uses a more accurate timing function
- Refactors S3 stream credential propagation