### PR TITLE
fix(serialization): Support serializing tensors over `write` size limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     buffers **and** parameters, leaving only persistent buffers
   - The corrected behaviour only filters out non-persistent buffers,
     leaving parameters untouched
+- Very large individual tensors (over approximately 2147479552 bytes)
+  now serialize correctly
+  - Previously, anything over the limit for a single `write` or `pwrite` syscall
+    could not be fully written, and an error was raised during serialization
+  - Now, multiple writes are used
+  - This also fixes large writes to unbuffered file-like objects if `pwrite`
+    is not supported, as they would encounter the same issue
 
 ## [2.7.2] - 2024-01-30
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -308,6 +308,7 @@ class TestSerialization(unittest.TestCase):
         num_elements: int = 36000 * 36000
         bytes_required: int = num_elements * 4
         assert bytes_required > 1 << 32
+        gc.collect()
         free_mem = utils.CPUMemoryUsage.now().free
         working_space: int = 10 << 20
         if free_mem < bytes_required + working_space:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -13,7 +13,7 @@ import sys
 import tempfile
 import time
 import unittest
-from typing import Iterator, Mapping, NamedTuple, Optional
+from typing import Iterator, Mapping, NamedTuple, Optional, Tuple
 from unittest.mock import patch
 
 import torch
@@ -126,18 +126,22 @@ def serialize_model_temp(*args, **kwargs):
 # model in many repeated tests
 class TensorInfo(NamedTuple):
     size: int
+    shape: Tuple[int, ...]
     dtype: torch.dtype
     hash: bytes
 
     @classmethod
     def from_tensor(cls, tensor: torch.Tensor) -> "TensorInfo":
+        shape = tuple(tensor.size())
         storage = tensor.untyped_storage().cpu()
         data = ctypes.cast(
             storage.data_ptr(),
             ctypes.POINTER(ctypes.c_ubyte * storage.nbytes()),
         ).contents
         hash_val = hashlib.blake2b(data, digest_size=16, salt=salt).digest()
-        return cls(size=tensor.size(), dtype=tensor.dtype, hash=hash_val)
+        return cls(
+            size=tensor.size(), shape=shape, dtype=tensor.dtype, hash=hash_val
+        )
 
 
 @functools.lru_cache(maxsize=None)
@@ -184,6 +188,13 @@ def check_deserialized(
             orig_info.size,
             f"Sizes don't match for tensor {k}: {v_info.size} !="
             f" {orig_info.size}",
+        )
+
+        test_case.assertEqual(
+            v_info.shape,
+            orig_info.shape,
+            f"Shapes don't match for tensor {k}: {v_info.shape} !="
+            f" {orig_info.shape}",
         )
 
         test_case.assertEqual(
@@ -292,8 +303,19 @@ class TestSerialization(unittest.TestCase):
                     os.unlink(serialized_model)
 
     def test_large_unbuffered_tensor(self):
-        shape = (36000, 36000)  # 4.828 GiB, > 2^32 total bytes (as float32)
-        tensor = torch.empty(shape, device="cpu", dtype=torch.float32)
+        shape = (36000, 36000)  # 4.828 GiB
+        dtype = torch.float32
+        num_elements: int = 36000 * 36000
+        bytes_required: int = num_elements * 4
+        assert bytes_required > 1 << 32
+        free_mem = utils.CPUMemoryUsage.now().free
+        working_space: int = 10 << 20
+        if free_mem < bytes_required + working_space:
+            self.skipTest(
+                reason="Insufficient RAM to test large tensor serialization"
+            )
+        low_mem: bool = free_mem < bytes_required * 2 + working_space
+        tensor = torch.empty(shape, device="cpu", dtype=dtype)
         tensor[0, 0] = 1.0101
         tensor[18000, 18000] = 1.2345
         tensor[-1, -1] = 5.4331
@@ -302,12 +324,30 @@ class TestSerialization(unittest.TestCase):
                 serializer = TensorSerializer(tensorized_file)
                 serializer.write_state_dict({"tensor": tensor})
                 serializer.close()
+            del serializer
+            if low_mem:
+                serialized_digest = TensorInfo.from_tensor(tensor)
+                tensor = None
+                gc.collect()
+            else:
+                serialized_digest = None
             with open(
                 tensorized_file.name, "rb"
             ) as in_file, TensorDeserializer(
-                in_file, device=tensor.device
+                in_file, device="cpu"
             ) as deserializer:
-                self.assertTrue(torch.equal(tensor, deserializer["tensor"]))
+                deserialized_tensor = deserializer["tensor"]
+                if low_mem:
+                    deserialized_digest = TensorInfo.from_tensor(
+                        deserialized_tensor
+                    )
+                    self.assertTupleEqual(
+                        serialized_digest, deserialized_digest
+                    )
+                else:
+                    self.assertTrue(torch.equal(tensor, deserialized_tensor))
+        del deserializer, tensor, deserialized_tensor
+        gc.collect()
 
     def test_bfloat16(self):
         shape = (50, 50)


### PR DESCRIPTION
# Large Tensor Serialization Support

This change fixes serialization for large tensors (roughly over 2147479552 bytes in a single tensor) by using multiple calls to `write` or `pwrite` when not everything is written during the first call.
This also enhances support for serializing to an unbuffered Python file-like object, since those can have similar behaviour.