### PR TITLE
fix(examples): Ensure using non-cached endpoint when validating

### DIFF
--- a/examples/hf_serialization.py
+++ b/examples/hf_serialization.py
@@ -4,6 +4,7 @@ import io
 import json
 import logging
 import os
+import re
 import tempfile
 import time
 import zipfile
@@ -34,7 +35,24 @@ from tensorizer import TensorDeserializer, TensorSerializer, stream_io, utils
 
 s3_access_key_id = os.environ.get("S3_ACCESS_KEY_ID") or None
 s3_secret_access_key = os.environ.get("S3_SECRET_ACCESS_KEY") or None
-s3_endpoint = "object.ord1.coreweave.com"  # To prevent caching old files
+s3_endpoint = os.environ.get("S3_ENDPOINT_URL") or None
+
+if s3_endpoint is None and (
+    s3_access_key_id is None or s3_secret_access_key is None
+):
+    s3_endpoint = stream_io._infer_credentials(
+        s3_access_key_id, s3_secret_access_key, s3_endpoint
+    ).s3_endpoint
+    if s3_endpoint is None:
+        s3_endpoint = stream_io.default_s3_read_endpoint
+s3_endpoint = re.sub(
+    r"^accel-(object\.\w+\.coreweave\.com)",
+    r"\1",
+    s3_endpoint,
+    1,
+    re.IGNORECASE,
+)
+
 
 _read_stream, _write_stream = (
     partial(

--- a/examples/hf_serialization.py
+++ b/examples/hf_serialization.py
@@ -34,7 +34,7 @@ from tensorizer import TensorDeserializer, TensorSerializer, stream_io, utils
 
 s3_access_key_id = os.environ.get("S3_ACCESS_KEY_ID") or None
 s3_secret_access_key = os.environ.get("S3_SECRET_ACCESS_KEY") or None
-s3_endpoint = os.environ.get("S3_ENDPOINT_URL") or None
+s3_endpoint = "object.ord1.coreweave.com"  # To prevent caching old files
 
 _read_stream, _write_stream = (
     partial(

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,4 +1,4 @@
-transformers~=4.27.1
+transformers~=4.34.0 # Needed to serialize Mistral-7B
 diffusers==0.14.0
 scipy~=1.10.0
-accelerate==0.17.1
+accelerate==0.20.3 # Needed to serialize Mistral-7B


### PR DESCRIPTION
This fix enforces `s3_endpoint = "object.ord1.coreweave.com"` for writes as well as reads in `hf_serialization.py` rather than `"accel-object.ord1.coreweave.com"` to prevent unwanted caching of model tensors. Caching tensors isn't helpful for a workflow with the sole purpose of serializing and validating model tensors, as this would just prevent overwritten tensors from being used for validation, instead using the older, cached ones. Additionally, updated `transformers` and `accelerate` dependencies to allow running `Mistral-7B`.