### PR TITLE
perf(serialization): Use Linux `fallocate` instead of `posix_fallocate`

### DIFF
--- a/tensorizer/_syscalls.py
+++ b/tensorizer/_syscalls.py
@@ -1,0 +1,97 @@
+import ctypes
+import errno
+
+__all__ = (
+    "has_fallocate",
+    "try_fallocate",
+)
+
+
+try:
+    _libc = ctypes.CDLL(None)
+except TypeError:
+    _libc = ctypes.pythonapi
+
+_IN: int = 1
+
+
+def _errcheck(result, func, args) -> None:
+    del args
+    if result == -1:
+        err: int = ctypes.get_errno()
+        str_err: str = errno.errorcode.get(err, "Unknown error")
+        raise OSError(err, str_err)
+    elif result == 0:
+        return None
+    else:
+        raise OSError("Unknown return code")
+
+
+def _get_fallocate():
+    from ctypes import CFUNCTYPE, c_int, c_longlong
+
+    prototype = CFUNCTYPE(
+        c_int,
+        c_int,
+        c_int,
+        c_longlong,
+        c_longlong,
+        use_errno=True,
+    )
+    paramflags = (
+        (_IN, "fd"),
+        (_IN, "mode"),
+        (_IN, "offset"),
+        (_IN, "len"),
+    )
+
+    try:
+        _func = prototype(("fallocate", _libc), paramflags)
+    except AttributeError:
+        return None
+    _func.errcheck = _errcheck
+
+    return _func
+
+
+_fallocate = _get_fallocate()
+del _get_fallocate
+
+
+def has_fallocate() -> bool:
+    """
+    Checks if the Linux ``fallocate(2)`` syscall is available.
+    Returns: ``True`` if ``fallocate(2)`` is available, ``False`` otherwise.
+    """
+    return _fallocate is not None
+
+
+def try_fallocate(
+    fd: int, offset: int, length: int, suppress_all_errors: bool = False
+) -> bool:
+    """
+    Calls ``fallocate(2)`` on the given file descriptor `fd` if available,
+    ignoring some errors if unsuccessful.
+
+    Args:
+        fd: File descriptor on which to call ``fallocate(2)``.
+        offset: Starting position of the byte range to allocate.
+        length: Number of bytes to allocate.
+        suppress_all_errors: If True, ignore all errors from unsuccessful calls.
+            Otherwise, only ignores ``EOPNOTSUPP``.
+
+    Returns: ``True`` if fallocate ran successfully, ``False`` otherwise.
+    Raises:
+        OSError: If `suppress_all_errors` is ``False`` and the call failed
+            due to an error other than ``EOPNOTSUPP``.
+    """
+    if _fallocate is None:
+        return False
+    try:
+        _fallocate(fd=fd, mode=0, offset=offset, len=length)
+        return True
+    except OSError as e:
+        if suppress_all_errors or e.errno == errno.EOPNOTSUPP:
+            return False
+        else:
+            raise

--- a/tests/test_syscalls.py
+++ b/tests/test_syscalls.py
@@ -1,0 +1,52 @@
+import os
+import tempfile
+import unittest
+
+import tensorizer._syscalls as syscalls
+
+
+class TestSyscalls(unittest.TestCase):
+    def test_fallocate(self):
+        from tensorizer._syscalls import try_fallocate
+
+        has_fallocate: bool = syscalls.has_fallocate()
+
+        with tempfile.NamedTemporaryFile(mode="wb+") as file:
+            fd: int = file.fileno()
+            with self.subTest("Regular fallocate"):
+                self.assertEqual(
+                    try_fallocate(fd=fd, offset=50, length=1000),
+                    has_fallocate,
+                )
+                try:
+                    self.assertEqual(
+                        os.stat(fd).st_size, 1050 if has_fallocate else 0
+                    )
+                finally:
+                    os.ftruncate(fd, 0)
+            if not has_fallocate:
+                # The rest of the tests check for errors, which cannot be raised
+                # if the fallocate syscall is not actually available.
+                return
+            with self.subTest(
+                "Invalid fallocate invocation, errors suppressed"
+            ):
+                self.assertFalse(
+                    try_fallocate(
+                        fd=fd, offset=-1, length=0, suppress_all_errors=True
+                    )
+                )
+            with self.subTest(
+                "Invalid fallocate invocation (bad offset and length)"
+            ), self.assertRaises(OSError):
+                try_fallocate(fd=fd, offset=-1, length=0)
+            self.assertEqual(os.stat(fd).st_size, 0)
+        with self.subTest(
+            "Invalid fallocate invocation (bad file descriptor)"
+        ), self.assertRaises(OSError):
+            try:
+                r_fd, w_fd = os.pipe()
+                try_fallocate(fd=w_fd, offset=0, length=1000)
+            finally:
+                os.close(r_fd)
+                os.close(w_fd)


### PR DESCRIPTION
# Linux `fallocate`

This change switches the `posix_fallocate` pre-allocation step during serialization to instead use the [Linux `fallocate(2)` syscall](https://linux.die.net/man/2/fallocate), skipping pre-allocation if it is not supported (e.g. if the call raises `EOPNOTSUPP`).

Previously, calling `posix_fallocate` on filesystems that do not support native `fallocate` behaviour would result in extremely poor performance from manually writing zeroes to a file. Since pre-allocation only exists as a performance optimization anyway, it's better to skip it when it is not available.