### PR TITLE
perf(serialization): Use optimal linear partitioning to divide segments

### DIFF
--- a/tensorizer/_linear_partition.py
+++ b/tensorizer/_linear_partition.py
@@ -124,9 +124,9 @@ def linear_partition(
                 best = best_prefix_partition[end, partitions_remaining]
                 if (
                     prefer_fewer
-                    and largest_partition <= best
-                    or not prefer_fewer
                     and largest_partition < best
+                    or not prefer_fewer
+                    and largest_partition <= best
                 ):
                     # If forming a partition here gave
                     # a record low outcome, record it.

--- a/tensorizer/_linear_partition.py
+++ b/tensorizer/_linear_partition.py
@@ -1,0 +1,188 @@
+from typing import Iterable, List, Sequence
+
+import numpy as np
+
+
+__all__ = ("partition",)
+
+
+def partition(
+    weights: Sequence[int],
+    partitions: int,
+    prefer_fewer: bool = True,
+    performance_threshold: int = 250000,
+) -> Iterable[slice]:
+    """
+    Partitions a sequence of weights into slices with balanced sums,
+    without changing the ordering of elements.
+    Balancing minimizes the largest sum of any resulting slice.
+    Args:
+        weights: Element weights to balance.
+        partitions: The maximum number of slices to return.
+            May return fewer if there are too few weights.
+        prefer_fewer: Enables returning fewer slices than requested
+            if the optimal partitioning scheme with at most `partitions`
+            partitions does not need exactly `partitions` slices.
+            For example, asking for 3 slices of ``[5, 2, 2]``
+            could return ``[[5], [2, 2]]``, since splitting again
+            to ``[[5], [2], [2]]`` doesn't improve the largest slice's sum.
+        performance_threshold: Limit for the number of comparisons that would
+            be used to calculate an optimal partitioning scheme. If more than
+            this many comparisons would be needed, an asymptotically faster
+            greedy approximation is used instead.
+
+    Returns:
+        An iterable of ``slice`` objects denoting ranges of the original
+        sequence that belong to each partition.
+
+    Examples:
+        Balancing a list of integers::
+
+            ints = [2, 8, 10, 5, 5]
+            split = [ints[s] for s in partition(ints, 3)]
+            assert split == [[2, 8], [10], [5, 5]]
+
+        Balancing a list of strings by length::
+
+            strings = ["abc", "ABC", "12345", "XYZ", "654321"]
+            weights = [len(s) for s in strings]
+            split = [strings[s] for s in partition(weights, 4)]
+            assert split == [["abc", "ABC"], ["12345"], ["XYZ"], ["654321"]]
+    """
+    n: int = len(weights)
+    partitions = min(n, partitions)
+    if (
+        partitions <= 2
+        or partitions * (n * (n + 1) // 2) > performance_threshold
+    ):
+        return greedy_linear_partition(weights, partitions)
+    else:
+        return linear_partition(weights, partitions, prefer_fewer)
+
+
+def linear_partition(
+    weights: Sequence[int], partitions: int, prefer_fewer: bool = True
+) -> Iterable[slice]:
+    # Dynamic programming solution to the linear partitioning problem
+    # based on Dr. Steven Skiena's algorithm & lecture notes.
+    # This finds an exact, optimal solution that has the smallest maximum sum
+    # in any partition. It provides no guarantees that the other partitions
+    # are perfect balanced, as long as they each have smaller sums than
+    # the largest partition.
+    # Time complexity: O(partitions * (len(weights) ** 2))
+    # Space complexity: O(partitions * len(weights))
+    n: int = len(weights)
+    partitions = min(partitions, n)
+    if partitions <= 1:
+        return (slice(0, n),)
+    prefix_sums: np.ndarray = np.cumsum(weights, dtype=np.uint64)
+    inf: np.ndarray = np.array(-1).astype(np.uint64)
+    # Entries in best_prefix_partition represent the lowest cost for a prefix,
+    # given two parameters:
+    # - Row: end position of the prefix
+    # - Column: number of allowed new partitions
+    # The lowest cost is the size of the largest partition in that prefix
+    # assuming the partitions are balanced optimally
+    best_prefix_partition: np.ndarray = np.full(
+        (n, partitions), inf, dtype=np.uint64
+    )
+
+    # Each row represents a different prefix
+    # No new partitions means no splitting; the total weight is the whole prefix
+    best_prefix_partition[:, 0] = prefix_sums
+
+    # Each column represents splitting into a different number of partitions
+    # Since the first row is a prefix with only one item,
+    # regardless of the number of partitions, it will have the same maximum
+    # weight (that single weight)
+    best_prefix_partition[0, :] = weights[0]
+
+    partition_starts: np.ndarray = np.empty(
+        (n - 1, partitions - 1), dtype=np.uint64
+    )
+    # The columns in partition_starts mean the same as the columns in
+    # best_prefix_partition, except row & column 0 would be meaningless,
+    # so we remove them, since there's nothing to end if there are no new
+    # partitions allowed, and nothing precedes position 0.
+    # The rows in partition_starts are a lookup table
+    # An entry at partition_starts[end, k] being `start` means the optimal
+    # partition ending immediately before `end` starts at `start`,
+    # with k other partitions behind it.
+    # The final partition indices come from iterated application of
+    # looking up `end` in partition_starts, and replacing it with the result
+    for end in range(1, n):
+        for partitions_remaining in range(1, partitions):
+            for start in range(end):
+                # If you form a new partition between `start` and `end`,
+                # then the largest sum overall is either the new one,
+                # or the previous largest sum in everything preceding `start`
+                # (with fewer allowed partitions)
+                largest_partition = max(
+                    best_prefix_partition[start, partitions_remaining - 1],
+                    prefix_sums[end] - prefix_sums[start],
+                )
+                best = best_prefix_partition[end, partitions_remaining]
+                if (
+                    prefer_fewer
+                    and largest_partition <= best
+                    or not prefer_fewer
+                    and largest_partition < best
+                ):
+                    # If forming a partition here gave
+                    # a record low outcome, record it.
+                    # If prefer_fewer is true, this may result in fewer
+                    # partitions than originally requested, if adding more
+                    # wouldn't reduce the maximum partition size either way
+                    best_prefix_partition[end, partitions_remaining] = (
+                        largest_partition
+                    )
+                    partition_starts[end - 1, partitions_remaining - 1] = start
+    del best_prefix_partition
+    slices = []
+    end = n - 1
+    for partitions_remaining in range(partitions - 1, 0, -1):
+        start = int(partition_starts[end - 1, partitions_remaining - 1])
+        # The algorithm calculates an inclusive endpoint,
+        # so end at end + 1 to include it, and start at start + 1
+        # to not overlap with the next slice
+        slices.append(slice(start + 1, end + 1))
+        end = start
+        if end == 0:
+            break
+    slices.append(slice(0, end + 1))
+    slices.reverse()
+
+    return slices
+
+
+def greedy_linear_partition(
+    weights: Sequence[int], partitions: int
+) -> Iterable[slice]:
+    # Greedy approximation for the linear partitioning problem, adapted from:
+    # https://www.werkema.com/2021/11/01/an-efficient-solution-to-linear-partitioning/
+    # Time complexity: O(len(weights))
+    # Space complexity: O(partitions)
+    # Could have O(1) space if changed to be a generator
+    partitions = min(len(weights), partitions)
+    if partitions <= 1:
+        return (slice(0, len(weights)),)
+
+    # This implementation scales weights by 2 * partitions to avoid fractions
+    target_size: int = sum(weights) * 2
+    current_size: int = 0
+
+    groups: List[slice] = []
+    start: int = 0
+
+    for end, weight in enumerate(weights):
+        scaled_weight: int = weight * partitions
+        current_size += scaled_weight * 2
+        if current_size > target_size + scaled_weight:
+            groups.append(slice(start, end))
+            start = end
+            if len(groups) == partitions - 1:
+                break
+            current_size -= target_size
+
+    groups.append(slice(start, len(weights)))
+    return groups

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -48,6 +48,7 @@ import torch
 
 import tensorizer._crypt as _crypt
 import tensorizer._crypt_info as _crypt_info
+import tensorizer._linear_partition as _linear_partition
 import tensorizer.stream_io as stream_io
 import tensorizer.utils as utils
 from tensorizer._crypt._cgroup_cpu_count import (
@@ -2222,41 +2223,31 @@ class TensorDeserializer(
         # Main route for multiple keys
 
         # Each reader will sequentially read a segment of the file
-        # Chunk up the keys into approximately similiar amounts of bytes to read per reader
-        # there are probably algorithms to do this more optimally
-        tensor_sizes = [(name, self._metadata[name].deserialized_length) for name in keys]
+        # Segments are chosen to minimize the maximum length of any segment
+        tensor_info: Tuple[TensorEntry, ...] = tuple(
+            map(self._metadata.__getitem__, keys)
+        )
+        tensors_per_reader: List[Tuple[TensorEntry, ...]]
         if self._num_readers == 1:
-            tensors_per_reader = [tensor_sizes]
+            tensors_per_reader = [tensor_info]
         else:
             if not isinstance(self._file_spec, (str, bytes, os.PathLike, int)):
                 raise Exception("File specifier must be a string to support concurrent readers ")
 
-            total_tensor_bytes = sum(tensor_size for _, tensor_size in tensor_sizes)
-            ideal_tensor_bytes_per_reader = int(total_tensor_bytes / self._num_readers)
-
-            tensors_per_reader = []
-            running_total = 0
-            chunk_start = 0
-            for tensor_size_idx in range(len(tensor_sizes)):
-                # if this tensor would make this current reader more than ideal_tensor_bytes_per_reader, and there's at least one existing item in the reader
-                if running_total + tensor_sizes[tensor_size_idx][1] > ideal_tensor_bytes_per_reader and chunk_start != tensor_size_idx:
-                    # break it
-                    tensors_per_reader.append(tensor_sizes[chunk_start:tensor_size_idx])
-                    chunk_start = tensor_size_idx
-                    running_total = 0
-                running_total += tensor_sizes[tensor_size_idx][1]
-
-            if running_total:
-                # The last one gets the leftovers
-                if not tensors_per_reader:
-                    tensors_per_reader.append([])
-
-                tensors_per_reader[-1].extend(tensor_sizes[chunk_start:])
+            tensor_sizes: List[int] = [
+                t.deserialized_length for t in tensor_info
+            ]
+            reader_slices: Iterable[slice] = _linear_partition.partition(
+                tensor_sizes, self._num_readers
+            )
+            tensors_per_reader = [tensor_info[s] for s in reader_slices]
+            del tensor_sizes, reader_slices
+        effective_num_readers: int = len(tensors_per_reader)
 
         transfer_out_queue = queue.SimpleQueue()  # type: queue.SimpleQueue[Union[Exception, TensorDeserializer._CopiedData]]
 
         copy_threads = []
-        barrier = threading.Barrier(len(tensors_per_reader))
+        barrier = threading.Barrier(effective_num_readers)
         halt = AtomicUint(width=4)
 
         for thread_idx, tensor_items in enumerate(tensors_per_reader):
@@ -2293,7 +2284,7 @@ class TensorDeserializer(
             halt: AtomicUint,
             barrier: threading.Barrier,
             verify_hash: bool,
-            tensor_items: Sequence[Tuple[str, int]],  # (name, size)
+            tensor_items: Sequence[TensorEntry],
             transfer_out_queue  # type: queue.SimpleQueue[Union[Exception, TensorDeserializer._CopiedData]]
     ):
         # Need to get rid of self or more safely have thread-local storage
@@ -2308,8 +2299,8 @@ class TensorDeserializer(
         # ensure all threads are created before we go
         barrier.wait()
 
-        begin_offset = unsafe_self._metadata[tensor_items[0][0]].offset
-        end_offset = unsafe_self._metadata[tensor_items[-1][0]].data_offset + unsafe_self._metadata[tensor_items[-1][0]].data_length
+        begin_offset = tensor_items[0].offset
+        end_offset = tensor_items[-1].data_offset + tensor_items[-1].data_length
 
         if unsafe_self._num_readers > 1:
             assert isinstance(unsafe_self._file_spec, str)
@@ -2324,11 +2315,15 @@ class TensorDeserializer(
 
             buffer_ptr = None
             if is_cuda:
-                total_tensor_bytes = max(size for _, size in tensor_items)
+                total_tensor_bytes: int = max(
+                    t.deserialized_length for t in tensor_items
+                )
                 buffer_tensor = torch.empty((total_tensor_bytes,), dtype=torch.uint8, pin_memory=True)
                 buffer_ptr = buffer_tensor.data_ptr()
 
-            tensor_sizes_by_name = dict(tensor_items)
+            tensor_sizes_by_name: Dict[str, int] = {
+                t.name: t.deserialized_length for t in tensor_items
+            }
 
             # then for each tensor in tensor_items
             tensors_read = 0


### PR DESCRIPTION
# Linear Partitioning

This improves the algorithm used to assign segments of a file to reader threads in #87.

An $O(n^{2} \cdot k)$ time, $O(n \cdot k)$ space (where $n$ = number of tensors, $k$ = requested number of readers) dynamic programming algorithm for optimal linear partitioning is used when $\frac{n \cdot (n + 1)}{2} \cdot k \lt 250000$, (less than 250000 comparison operations, about 250 tensors with 8 readers, takes about 140 ms).

When the number of comparison operations to compute the optimal partitioning scheme would be too large, it reverts to [an efficient greedy algorithm originally designed by Sean Werkema](https://www.werkema.com/2021/11/01/an-efficient-solution-to-linear-partitioning/) that takes $O(n)$ time and $O(k)$ space.