### PR TITLE
fix(examples): Move non-persistent buffers to a valid device

### DIFF
--- a/examples/deserialize.py
+++ b/examples/deserialize.py
@@ -19,19 +19,26 @@ config = AutoConfig.from_pretrained(model_ref)
 with no_init_or_tensor():
     model = AutoModelForCausalLM.from_config(config)
 
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+print(f"Deserializing to {device}:")
 before_mem = get_mem_usage()
 
 # Lazy load the tensors from S3 into the model.
 start = time.time()
-deserializer = TensorDeserializer(s3_uri)
+deserializer = TensorDeserializer(s3_uri, device=device)
 deserializer.load_into_module(model)
 end = time.time()
+
+after_mem = get_mem_usage()
+
+# Move any remaining non-persistent buffers to the correct device
+# (buffers generated programmatically, not part of deserialization)
+model = model.to(device)
 
 # Brag about how fast we are.
 total_bytes_str = convert_bytes(deserializer.total_tensor_bytes)
 duration = end - start
 per_second = convert_bytes(deserializer.total_tensor_bytes / duration)
-after_mem = get_mem_usage()
 deserializer.close()
 print(f"Deserialized {total_bytes_str} in {end - start:0.2f}s, {per_second}/s")
 print(f"Memory usage before: {before_mem}")
@@ -43,7 +50,7 @@ tokenizer = AutoTokenizer.from_pretrained(model_ref)
 eos = tokenizer.eos_token_id
 input_ids = tokenizer.encode(
     "¡Hola! Encantado de conocerte. hoy voy a", return_tensors="pt"
-).to("cuda")
+).to(device)
 
 with torch.no_grad():
     output = model.generate(


### PR DESCRIPTION
# Non-persistent buffer devices

During deserialization using `load_into_module`, only the buffers loaded from the deserializer are overwritten on the target module, and any extra buffers on the target module remain unmodified. This can lead to an error if there are existing buffers on the target module that are on a different device from the deserializer, since the model will end up scattered across multiple devices.

This primarily arises as an issue when serializing with `include_non_persistent_buffers=False`, since non-persistent buffers may be created on any device, and will not be overwritten by the deserializer. In particular, this led to an error when running the code in `deserialize.py` (which does not expect buffers from anything but the deserializer) on a model serialized using `examples/hf_serialization.py` (which uses `include_non_persistent_buffers=False`).

This change adds an extra section to `deserialize.py` that moves remaining non-persistent buffers to a device matching the deserializer after regular deserialization finishes. It is not included in the speed measurement because non-persistent buffers are explicitly not any business of the deserializer—only of external code—and they can be included and measured by setting `include_non_persistent_buffers=True` if it is desired to force the deserializer to handle them instead.