### PR TITLE
fix(redis): relax Redis requirements to `>=4.5.5` from `==5.0.0`.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "protobuf>=3.19.5",
     "psutil>=5.9.4",
     "boto3>=1.26.0",
-    "redis>=5.0.0",
+    "redis>=4.5.5",
     "hiredis>=2.2.0",
     "libnacl>=2.1.0"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ numpy>=1.19.5
 protobuf>=3.19.5
 psutil>=5.9.4
 boto3>=1.26.0
-redis==5.0.0
+redis>=4.5.5
 hiredis
 libnacl>=2.1.0


### PR DESCRIPTION
Customer has a hard requirement for `redis==4.5.5` due to bugs in `5.0.0` for their use case. This relaxes the requirement to `redis>=4.5.5` from `redis==5.0.0`.

Test cases pass for Redis with `4.5.5`.