### PR TITLE
perf(serialization) Reuse a pinned buffer when copying from gpu

### DIFF
--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -3834,7 +3834,7 @@ class TensorSerializer:
         else:
             transferred = queue.Queue(maxsize=max_read_ahead)
 
-        biggest_tensor_bytes = max(t.nbytes for t in tensors)
+        biggest_tensor_bytes = max(t.element_size() * t.nelement() for t in tensors)
         staging_tensor = torch.empty(
             (biggest_tensor_bytes,), dtype=torch.uint8, device="cpu", pin_memory=True
         )


### PR DESCRIPTION
Similar to plaid mode, re-use one pinned buffer to handle the data transfer from GPU to CPU for serialization.

In main, serializing gpt-j-6B fp16 to nvme took 8.375s
In this branch, takes 4.796s