### PR TITLE
fix: Avoid regressions, add tests, better reference handling, misc. logic errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,12 +441,23 @@ of a model if you use the `accel-object.ord1.coreweave.com` endpoint.
 `tensorizer` has a few additional features that make it more useful than
 just a serialization/deserialization tool.
 
-### Concurrent reads
+### Concurrent Reads
 
-The `TensorDeserializer` class has an argument called `num_readers` that affects how many concurrent reading threads can read from the source at the same time.
-This can greatly improve performance, since in many cases the network or the file is the bottleneck. A few caveats to running with `num_readers > 1`:
-* The specified file must be a string; either a URI or file path, so that the Deserializer can open more streams against the source.
-* For HTTP and S3 URIs, the host must support the `Range` header. Each reader will read a stream from a different Range offset in the source.
+The `TensorDeserializer` class has a `num_readers` argument that controls
+how many threads are allowed to read concurrently from the source file.
+This can greatly improve performance, since in many cases the network or the
+file is the bottleneck. A few caveats to running with `num_readers > 1`:
+
+* The specified file must be able to be reopened, so that the
+  `TensorDeserializer` can open more streams against the source.
+  * Local files, paths, and HTTP(S) and S3 URIs / open streams
+    are all able to be reopened
+  * Special files like pipes and sockets, or synthetic file-like objects such as
+    `BytesIO` are not currently able to be reopened
+* For HTTP(S) and S3 streams and URIs, the host must support the `Range` header.
+  Each reader will read a stream from a different Range offset in the source.
+
+The default is `num_readers=1`, which has no special requirements.
 
 ### `state_dict` Support
 

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -2397,9 +2397,9 @@ class TensorDeserializer(
             del tensor_sizes, reader_slices
         effective_num_readers = len(tensors_per_reader)
 
-        transfer_out_queue: queue.SimpleQueue[
-            Union[Exception, TensorDeserializer._CopiedData]
-        ] = queue.SimpleQueue()
+        copy_result = Union[Exception, TensorDeserializer._CopiedData]
+        transfer_out_queue: "queue.SimpleQueue[copy_result]"
+        transfer_out_queue = queue.SimpleQueue()
 
         futures: List[concurrent.futures.Future] = []
         barrier = threading.Barrier(effective_num_readers)
@@ -2419,7 +2419,7 @@ class TensorDeserializer(
 
         try:
             for _ in range(len(keys)):
-                copied_data = transfer_out_queue.get(timeout=3600)
+                copied_data: copy_result = transfer_out_queue.get(timeout=3600)
                 if isinstance(copied_data, Exception):
                     raise copied_data
                 yield copied_data
@@ -2429,13 +2429,13 @@ class TensorDeserializer(
             raise
 
     def _copy_thread(
-            unsafe_self,
-            thread_idx: int,
-            halt: AtomicUint,
-            barrier: threading.Barrier,
-            verify_hash: bool,
-            tensor_items: Sequence[TensorEntry],
-            transfer_out_queue: queue.SimpleQueue[Union[Exception, _CopiedData]]
+        unsafe_self,
+        thread_idx: int,
+        halt: AtomicUint,
+        barrier: threading.Barrier,
+        verify_hash: bool,
+        tensor_items: Sequence[TensorEntry],
+        transfer_out_queue: "queue.SimpleQueue[Union[Exception, _CopiedData]]"
     ):
         # Need to get rid of self or more safely have thread-local storage
 

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -594,6 +594,7 @@ class CURLStreamFile(io.BufferedIOBase):
             end=end,
             headers=self._headers,
             buffer_size=self._buffer_size,
+            certificate_handling=self._certificate_handling,
         )
         clone._error_context.extend(self._error_context)
         return clone

--- a/tests/test_stream_io.py
+++ b/tests/test_stream_io.py
@@ -39,11 +39,11 @@ class TestCurlStream(unittest.TestCase):
         self.assertEqual(b"GPT Neo", stream.read(7))
 
     def test_curl_stream_end(self):
-        stream = stream_io.CURLStreamFile(NEO_URL, end=2)
+        stream = stream_io.CURLStreamFile(NEO_URL, end=1)
         self.assertEqual(b"# ", stream.read(5))
 
     def test_curl_stream_buffer_end(self):
-        stream = stream_io.CURLStreamFile(NEO_URL, end=2)
+        stream = stream_io.CURLStreamFile(NEO_URL, end=1)
         ba = bytearray(5)
         self.assertEqual(2, stream.readinto(ba))
         self.assertEqual(b"# \x00\x00\x00", ba)


### PR DESCRIPTION
# Various Fixes for #87

This PR contains various fixes and performance tweaks for #87.

Highlights:
- Open files and `CURLStreamFile`s can be used with `num_readers > 1`
- The linear partitioning algorithm has greatly improved performance and correctness
  - Around 25x faster in a common configuration
- `num_tensors=-1` following other partial reads works correctly
- Buffer pointers and artificial references to their sources are avoided in favour of `memoryview`s that directly hold strong references to their sources, lowering the likelihood of memory getting garbage collected while still in use
- Some cryptic error causing S3 reads with `num_readers > 1` to fail has been resolved
- Multiple separate reads share a thread pool
- HTTP `Range` end offsets are requested and handled correctly
- HTTP `Range`s have more thorough error checking in the `CURLStreamFile` constructor
- `CURLStreamFile`s try not to over-allocate file or pipe buffers when expecting to read a small range
- (Not directly related to #87) `stream_io.open_stream` is only allowed to open local files when passed a path-like object instead of a string
- `_bulk_load` permits requests for out-of-order keys
- `_bulk_load`'s reordering scheme has better asymptotic complexity (my original suggestion to use `heapq` was sub-optimal)
- PyTorch versions below 2.1 are supported again
- The original open file is used by the first reader thread to not waste its open connection and its read-ahead data
- `KeyboardInterrupt`s can trigger reader thread shutdown
- Reverted the extra error case in `verify_module`, since the conditions for it were removed in a later revision
- New tests have been added for CPU and S3 deserialization with `num_readers > 1`, also using the new reopening functionality for file-like objects