### PR TITLE
fix(serialization): Limit `read_numpy_arrays` to CPU deserialization

### DIFF
--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -2366,6 +2366,10 @@ class TensorDeserializer(
             HashMismatchError: If ``verify_hash`` resolves to True and
                 a deserialized tensor does not match its stored hash.
         """
+        if self._device.type != "cpu":
+            raise RuntimeError(
+                "read_numpy_arrays is only valid when deserializing to the CPU"
+            )
         data = self._read_numpytensors(
             filter_func=filter_func,
             num_tensors=num_tensors,


### PR DESCRIPTION
# Making `read_numpy_arrays` CPU-only

## :sparkles: Happy 100th `tensorizer` issue/PR! :tada:

`TensorDeserializer.read_numpy_arrays()` returned unstable results when a `TensorDeserializer`'s `device` parameter was set to a CUDA device. `numpy` arrays cannot be deserialized to CUDA, since `numpy` is a CPU-only library, but the returned CPU buffers still used `plaid_mode` CUDA-oriented semantics, and thus were corrupted shortly after being returned. (This also affects `TensorDeserializer.read_tensors()`, but that will be resolved soon by #87, which will enable that function to properly yield CUDA tensors.)

This PR resolves this issue by raising an error when calling `TensorDeserializer.read_numpy_arrays()` but not deserializing to the CPU, as attempting to do so is contradictory anyway.