### PR TITLE
perf(serialization) Make tensors contiguous via thread pool

### DIFF
--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -3852,10 +3852,10 @@ class TensorSerializer:
         write_specs = collections.deque(write_specs)
         next_pos = self._file.tell()
         if _syscalls.has_fallocate() and self._fd:
-            size = sum(len(t.name) for t in tensors)
+            size = sum(len(w.name) for w in write_specs)
             size += sum(
-                t.tensor.element_size()
-                * t.tensor.nelement()
+                w.tensor.element_size()
+                * w.tensor.nelement()
                 * (not w.tensor.is_meta)
                 for w in write_specs
             )
@@ -3880,7 +3880,7 @@ class TensorSerializer:
                     w.tensor,
                     _synchronize=False,
                     _start_pos=next_pos,
-                    _temporary_buffer=w.temp_tensor,
+                    _temporary_buffer=w.temporary_buffer,
                 )
                 if w.callback is not None:
                     w.callback()


### PR DESCRIPTION
Making tensors contiguous() can be CPU-intensive, so throw that to a thread pool. Along the way, refactor the part of `_bulk_write()` that prepares tensors into a separate method `_prepare_tensors_for_write()`.

This handles currently three separate possible operations on each tensor:
* transferring it from cuda
* `clone().detach()` for when the tensor shares memory with another tensor and encryption is enabled
* making it `contiguous()` if it isn't
* .. plus a no-op

Each of these operations are done in a thread or threadpool. It's almost a list of futures, except `_async_bulk_device_to_host_transfer()` handles a list of tensors all at once. So instead I use iterators.


`examples/serialize.py` with gpt-j-6b (w/o CUDA) takes 17s on main, 8.8s after this change. I'm not sure how much of an impact this will have on actual use cases. But it can't hurt, and the refactor helps make this more maintainable imo.