### PR TITLE
perf(serialization): Prefer `CURLStreamFile._fork` over `open_stream`

### DIFF
--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -6,7 +6,6 @@ import abc
 import collections.abc
 import concurrent.futures
 import contextlib
-import ctypes
 import dataclasses
 import enum
 import functools
@@ -1753,10 +1752,10 @@ class TensorDeserializer(
 
     def _reopen_func(self) -> Optional[Callable]:
         spec = self._file_spec
-        if isinstance(spec, (str, bytes, os.PathLike)):
+        if isinstance(self._file, stream_io.CURLStreamFile):
+            return self._file._fork
+        elif isinstance(spec, (str, bytes, os.PathLike)):
             return partial(stream_io.open_stream, spec, mode="rb")
-        elif isinstance(spec, stream_io.CURLStreamFile):
-            return spec._fork
         # Other types of files can be reopened under certain conditions
         fd: Optional[int] = None
         if hasattr(self._file, "fileno"):


### PR DESCRIPTION
# Prefer Forking Open Streams

When reopening `CURLStreamFile`s for multiple readers, this change makes the reopening logic prefer an existing `CURLStreamFile`'s `._fork` method rather than `open_stream`. `open_stream` is slow to call many times because it must re-compute the pre-signed URL each time, and the way we do that with `boto3` adds a decent amount of overhead.