### PR TITLE
fix(stream_io): Fix `accel-object` parsing with bucket name subdomains

### DIFF
--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -188,8 +188,8 @@ class CAInfo:
 
 
 def _is_accelerated_object_storage(uri: str) -> bool:
-    domain = urlparse(uri.lower()).hostname.split(".")
-    return (domain[0], *domain[1:]) == ("accel-object", "coreweave", "com")
+    domain = urlparse(uri.lower()).hostname.split(".")[-4:]
+    return (domain[0], *domain[2:]) == ("accel-object", "coreweave", "com")
 
 
 class CURLStreamFile(io.BufferedIOBase):


### PR DESCRIPTION
# Checking for `accel-object` correctly in virtual hosted bucket domain names

This change fixes a parsing bug that didn't correctly account for object storage endpoint domains prefixed by a bucket name subdomain. It also fixes an off-by-one error when gathering the list of components to check.