### PR TITLE
fix(serialization): Drop `atomics` dependency & make perf stats optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ description = "A tool for fast PyTorch module, model, and tensor serialization +
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-    "atomics>=1.0.2",
     "torch>=1.9.0",
     "numpy>=1.19.5",
     "protobuf>=3.19.5",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-atomics>=1.0.2
 torch>=1.9.0
 numpy>=1.22.2
 protobuf>=3.19.5


### PR DESCRIPTION
# Locking instead of atomics, and optional `_perf_stats`

This change switches from using the `atomics` package for synchronized variable access to explicit locking, to avoid errors thrown by that package's deallocation code, and also for performance (amusingly). Additionally, the internal-only `_perf_stats` gathered during deserialization are now optional, and are only collected if the environment variable `TENSORIZER_ENABLE_PERF_STATS` is set.