### PR TITLE
perf: Add a syscall-based GIL-free address prefaulting function

### DIFF
--- a/tensorizer/_syscalls.py
+++ b/tensorizer/_syscalls.py
@@ -127,7 +127,7 @@ def _get_madvise():
 _madvise = _get_madvise()
 del _get_madvise
 
-_madv_populate_read: int = 23
+_madv_populate_write: int = 23
 
 
 def _can_prefault_with_madvise() -> bool:
@@ -139,11 +139,11 @@ def _can_prefault_with_madvise() -> bool:
     flags = {} if private == 0 else {"flags": private}
     with mmap.mmap(-1, n, **flags) as m:
         try:
-            # MADV_POPULATE_READ is only available on Linux 5.14 and up
+            # MADV_POPULATE_WRITE is only available on Linux 5.14 and up
             _madvise(
                 ctypes.byref((ctypes.c_ubyte * n).from_buffer(m)),
                 n,
-                _madv_populate_read,
+                _madv_populate_write,
             )
         except OSError:
             return False
@@ -154,7 +154,7 @@ def _can_prefault_with_madvise() -> bool:
 if _can_prefault_with_madvise():
 
     def prefault(address, length: int):
-        _madvise(address, length, _madv_populate_read)
+        _madvise(address, length, _madv_populate_write)
 
 else:
 

--- a/tensorizer/_syscalls.py
+++ b/tensorizer/_syscalls.py
@@ -1,9 +1,11 @@
 import ctypes
 import errno
+import mmap
 
 __all__ = (
     "has_fallocate",
     "try_fallocate",
+    "prefault",
 )
 
 
@@ -95,3 +97,69 @@ def try_fallocate(
             return False
         else:
             raise
+
+
+def _get_madvise():
+    from ctypes import CFUNCTYPE, c_int, c_size_t, c_void_p
+
+    prototype = CFUNCTYPE(
+        c_int,
+        c_void_p,
+        c_size_t,
+        c_int,
+        use_errno=True,
+    )
+    paramflags = (
+        (_IN, "addr"),
+        (_IN, "length"),
+        (_IN, "advice"),
+    )
+
+    try:
+        _func = prototype(("madvise", _libc), paramflags)
+    except AttributeError:
+        return None
+    _func.errcheck = _errcheck
+
+    return _func
+
+
+_madvise = _get_madvise()
+del _get_madvise
+
+_madv_populate_read: int = 23
+
+
+def _can_prefault_with_madvise() -> bool:
+    if _madvise is None or _libc is ctypes.pythonapi:
+        # If _libc is ctypes.pythonapi then the call would hold the GIL
+        return False
+    n: int = mmap.PAGESIZE
+    private: int = getattr(mmap, "MAP_PRIVATE", 0)
+    flags = {} if private == 0 else {"flags": private}
+    with mmap.mmap(-1, n, **flags) as m:
+        try:
+            # MADV_POPULATE_READ is only available on Linux 5.14 and up
+            _madvise(
+                ctypes.byref((ctypes.c_ubyte * n).from_buffer(m)),
+                n,
+                _madv_populate_read,
+            )
+        except OSError:
+            return False
+        else:
+            return True
+
+
+if _can_prefault_with_madvise():
+
+    def prefault(address, length: int):
+        _madvise(address, length, _madv_populate_read)
+
+else:
+
+    def prefault(address, length: int):
+        ctypes.memset(address, 0x00, length)
+
+
+del _can_prefault_with_madvise


### PR DESCRIPTION
# GIL-Free Memory Prefaulting

This change adds a `tensorizer_syscalls.prefault` function that can fault pages in memory for writing without holding the GIL, allowing prefaulting to be multithreaded. This accelerates `cudaHostRegister` performance, since it then does not need to fault pages itself.

The `prefault` function uses `madvise` if `MADV_POPULATE_WRITE` is available (Linux 5.14+), or `memset` otherwise, which incurs unnecessary writes, but is still fairly fast. Its arguments must be page-aligned for compatibility with the `madvise` syscall.

No usages of this function are added in the PR—only the function itself, to aid in development of better allocation schemes in subsequent PRs.

Example usage:

```py
import ctypes
import mmap
from concurrent.futures import ThreadPoolExecutor

from tensorizer._syscalls import prefault

num_threads: int = 16
buffer_size: int = 4 << 30

with ThreadPoolExecutor(max_workers=num_threads) as pool, mmap.mmap(
    -1, buffer_size, flags=mmap.MAP_PRIVATE
) as m:
    buf = (ctypes.c_ubyte * buffer_size).from_buffer(m)
    try:
        chunk_size: int = buffer_size // num_threads
        offsets = (
            ctypes.byref(buf, i) for i in range(0, buffer_size, chunk_size)
        )
        sizes = (chunk_size,) * num_threads
        for _ in pool.map(prefault, offsets, sizes):
            pass
    finally:
        del buf
```