### PR TITLE
chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 exclude: ^.*_pb2\.py|ATTIC/.*$
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 24.3.0
     hooks:
       - id: black
-        language_version: python3.10
+        language_version: python3.12
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         args: ["--filter-files"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     rev: 24.3.0
     hooks:
       - id: black
-        language_version: python3.12
+        language_version: python3.10
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:

--- a/examples/benchmark_buffer_size/visualizations/visualizations.py
+++ b/examples/benchmark_buffer_size/visualizations/visualizations.py
@@ -478,7 +478,7 @@ def plot(
 def simple_plot(
     filename: Optional[Union[str, os.PathLike]] = (
         out_dir / "tensorizer-deserialization"
-    )
+    ),
 ):
     # Filter to the fewest variables possible
     filtered_schemes = ("s3", "redis", "s3s", "https")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ attr = "tensorizer._version.__version__"
 
 [tool.black]
 line-length = 80
-target-version = ["py38", "py39", "py310", "py311"]
+target-version = ["py38", "py39", "py310", "py311", "py312"]
 preview = true
 force-exclude = '''
 (

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -902,8 +902,7 @@ class EncryptionParams:
         __slots__ = ()
 
         @abc.abstractmethod
-        def chunk(self) -> _crypt_info.KeyDerivationChunk:
-            ...
+        def chunk(self) -> _crypt_info.KeyDerivationChunk: ...
 
     @dataclasses.dataclass
     class _FromStringPWHashAlgorithm(_Algorithm):

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -65,7 +65,7 @@ def _get_s3cfg_values(
         Union[
             Tuple[Union[str, bytes, os.PathLike], ...], str, bytes, os.PathLike
         ]
-    ] = None
+    ] = None,
 ) -> _ParsedCredentials:
     """
     Gets S3 credentials from the .s3cfg file.

--- a/tensorizer/utils.py
+++ b/tensorizer/utils.py
@@ -281,7 +281,7 @@ Model = TypeVar("Model")
 
 
 def no_init_or_tensor(
-    loading_code: Optional[Callable[..., Model]] = None
+    loading_code: Optional[Callable[..., Model]] = None,
 ) -> Union[Model, ContextManager]:
     """
     Suppress the initialization of weights while loading a model.

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -989,8 +989,7 @@ class TestDeserialization(unittest.TestCase):
                 " or matches all tensor names."
                 " Update the pattern and/or custom_check"
                 " to use more informative filtering criteria."
-                "\n\nTensors present in the model: "
-                + " ".join(all_keys)
+                "\n\nTensors present in the model: " + " ".join(all_keys)
             ),
         )
 


### PR DESCRIPTION
# Update pre-commit hooks

This change updates the pre-commit formatting hooks to use the latest versions of `black` and `isort`.