### PR TITLE
feat(serialization): Add serialization of structured objects

### DIFF
--- a/tensorizer/_tensor_path.py
+++ b/tensorizer/_tensor_path.py
@@ -1,0 +1,313 @@
+import dataclasses
+import json
+import operator
+import types
+import typing
+from typing import Callable, Dict, Iterable, Iterator, List, Tuple, Union
+
+# Tensor paths are made up of strings (for mapping keys)
+# and integers (for array indices)
+_TensorPathComponent: "typing.TypeAlias" = Union[str, int]
+
+
+class _TensorPath(tuple):
+    def serialized_(self) -> bytes:
+        if self.is_str_:
+            return self[0].encode("utf-8")
+        else:
+            # application/json-seq format
+            return b"\x1e" + json.dumps(
+                self, indent=None, ensure_ascii=True, separators=(",", ":")
+            ).encode("ascii")
+
+    @property
+    def is_str_(self) -> bool:
+        return len(self) == 1 and isinstance(self[0], str)
+
+    def normalize_(self) -> Union[tuple, str]:
+        return self[0] if self.is_str_ else tuple(self)
+
+    def __str__(self) -> str:
+        return str(self.normalize_())
+
+    def append_(self, other: Union[str, int]) -> "_TensorPath":
+        if not isinstance(other, (str, int)):
+            raise TypeError(f"Invalid key type: {other.__class__.__name__!r}")
+        else:
+            return self.__class__(self + (other,))
+
+    def validate_(self) -> None:
+        if not self:
+            raise ValueError("Invalid empty tensor path")
+        for i in self:
+            if not isinstance(i, (str, int)):
+                raise TypeError(
+                    "Invalid tensor path component type:"
+                    f" {i.__class__.__name__!r}"
+                )
+            if isinstance(i, int) and i < 0:
+                raise ValueError(
+                    f"Invalid negative integer tensor path component: {i}"
+                )
+
+    @classmethod
+    def wrap_(cls, value: Union["_TensorPath", tuple, str]) -> "_TensorPath":
+        if isinstance(value, cls):
+            return value
+        elif isinstance(value, tuple):
+            return cls(value)
+        else:
+            return cls((value,))
+
+    @staticmethod
+    def _invalid_hook(*_args, **_kwargs):
+        raise TypeError("Invalid deserialized type")
+
+    @classmethod
+    def deserialize_(cls, serialized: typing.ByteString) -> "_TensorPath":
+        if not isinstance(serialized, (bytes, bytearray, memoryview)):
+            raise TypeError(
+                "Invalid tensor path: expected byte string,"
+                f" got {serialized.__class__.__name__!r}"
+            )
+        if not serialized:
+            ret = cls()
+            ret.validate_()
+            return ret
+        is_mv: bool = isinstance(serialized, memoryview)
+        first_byte: int = serialized[0]
+        if first_byte == 0x1E:
+            if (
+                len(serialized) < 3
+                or serialized[1] != 0x5B  # "["
+                or serialized[-1] != 0x5D  # "]"
+            ):
+                # Require the form <RS>[...]
+                raise ValueError("Invalid tensor path: non-array json-seq")
+            if 0x0A in serialized or 0x0D in serialized:
+                raise ValueError("Illegal newline in json-seq")
+            try:
+                deserialized: List[Union[str, int]] = json.loads(
+                    serialized[1:].tobytes() if is_mv else serialized[1:],
+                    object_hook=cls._invalid_hook,
+                    parse_float=cls._invalid_hook,
+                    parse_constant=cls._invalid_hook,
+                )
+            except RecursionError as e:
+                raise ValueError(
+                    "Cannot deserialize tensor path due to excessive nesting"
+                ) from e
+            if not isinstance(deserialized, list):
+                raise TypeError(
+                    "Invalid deserialized type:"
+                    " expected array as top level object"
+                )
+            ret = cls(deserialized)
+            ret.validate_()
+            return ret
+        else:
+            if is_mv:
+                serialized = serialized.tobytes()
+            return cls((serialized.decode("utf-8"),))
+
+
+@dataclasses.dataclass
+class _TensorPathRegistry:
+    """
+    Tracks tensor paths used so far, throwing an error on prefix conflicts,
+    and building a prefix tree of layers of the nested structure.
+    """
+
+    __slots__ = "_registered_paths"
+    _registered_paths: dict
+
+    def __init__(self):
+        self._registered_paths = {}
+
+    def _check_compatible_types(self, path: _TensorPath) -> None:
+        branch = self._registered_paths
+        for depth, component in enumerate(path):
+            if not branch:
+                break
+            existing_type = type(next(iter(branch)))
+            current_type = type(component)
+            if existing_type is not current_type:
+                prefix: tuple = path[: depth + 1]
+                raise ValueError(
+                    "Conflicting tensor paths:"
+                    f" {path.normalize_()} has a different key type"
+                    f" ({current_type.__name__!r}) than existing keys at the"
+                    f" prefix {prefix} ({existing_type.__name__!r})"
+                )
+            if component not in branch:
+                break
+            branch = branch[component]
+
+    def register_path(self, path: Union[_TensorPath, str]) -> None:
+        branch: dict = self._registered_paths
+        if isinstance(path, str):
+            path = _TensorPath((path,))
+        if not isinstance(path, _TensorPath):
+            raise TypeError(
+                f"Invalid tensor path type: {path.__class__.__name__!r}"
+            )
+        if not path:
+            raise ValueError("Invalid empty tensor path")
+        self._check_compatible_types(path)
+        for component in path[:-1]:
+            branch = branch.setdefault(component, {})
+            if not isinstance(branch, dict):
+                raise ValueError(f"Conflicting tensor paths: {path}, {branch}")
+        component = path[-1]
+        if component in branch:
+            if isinstance(branch[component], dict):
+                raise ValueError(
+                    f"Conflicting tensor paths: {path.normalize_()} is both"
+                    " a leaf and a prefix of another path"
+                )
+            else:
+                raise ValueError(
+                    "Conflicting tensor paths:"
+                    f" {path.normalize_()} is used multiple times"
+                )
+        branch[component] = path
+
+    def filter(self, leaf_filter: Callable[[_TensorPath], bool]):
+        layers = [(self._registered_paths, iter(tuple(self._registered_paths)))]
+        while layers:
+            layer, layer_keys = layers[-1]
+            for k in layer_keys:
+                v = layer[k]
+                if isinstance(v, _TensorPath):
+                    # If this is a leaf, check if it needs to be pruned
+                    if not leaf_filter(v):
+                        del layer[k]
+                else:
+                    # Otherwise, recurse
+                    layers.append((v, iter(tuple(v))))
+                    break
+            else:
+                layers.pop()
+
+    def dict(self) -> dict:
+        return self._registered_paths
+
+
+def key_value_iterator(obj: Union[typing.Sequence, typing.Mapping]):
+    if isinstance(obj, typing.Mapping):
+        for k in obj.keys():
+            if not isinstance(k, str):
+                raise TypeError(
+                    "Invalid key type for state_dict: expected str, got"
+                    f" {k.__class__.__name__!r}"
+                )
+        return iter(obj.items())
+    elif isinstance(obj, typing.Sequence):
+        return enumerate(obj)
+    else:
+        raise TypeError(
+            "Cannot serialize type as part of a state_dict:"
+            f" {obj.__class__.__name__!r}"
+        )
+
+
+_LeafType = typing.TypeVar("_LeafType")
+
+
+def flatten_structure(
+    leaf_type: typing.Type[_LeafType],
+    obj: Union[List, typing.Mapping],
+    prefix: _TensorPath = _TensorPath(),
+) -> Iterable[Tuple[_TensorPath, _LeafType]]:
+    iters: List[Tuple[_TensorPath, Iterator]] = [
+        (prefix, key_value_iterator(obj))
+    ]
+    while iters:
+        pre, it = iters[-1]
+        for name, item in it:
+            path: _TensorPath = pre.append_(name)
+            if isinstance(item, leaf_type):
+                yield path, item
+            else:
+                iters.append((path, key_value_iterator(item)))
+                break
+        else:
+            iters.pop()
+
+
+def restructure(
+    flat: Dict[_TensorPath, _LeafType], use_dict_proxies: bool = False
+) -> Union[dict, list, types.MappingProxyType]:
+    for path in flat.keys():
+        if len(path) < 1:
+            raise ValueError("Invalid empty tensor path key")
+
+    # Start reconstructing everything as nested dictionaries
+    base = {}
+    for path, tensor in flat.items():
+        branch = base
+        for component in path[:-1]:
+            branch = branch.setdefault(component, {})
+            if not isinstance(branch, dict):
+                # Key path conflicts should be caught at the metadata
+                # parsing step, so this is just an extra sanity check
+                raise RuntimeError(f"Key path conflict for key {path}")
+        component = path[-1]
+        if component in branch:
+            raise RuntimeError(f"Key path conflict for key {path}")
+        branch[component] = tensor
+
+    # Assign a type to each layer separately
+    def re_type_layer(
+        untyped_layer: dict,
+    ) -> Union[dict, list, types.MappingProxyType]:
+        if use_dict_proxies:
+            return types.MappingProxyType(untyped_layer)
+        is_list = False
+        for key in untyped_layer:
+            if isinstance(key, int):
+                is_list = True
+                if key < 0:
+                    raise ValueError(
+                        "Illegal negative integer tensor path component"
+                    )
+            elif is_list:
+                raise ValueError(
+                    "Invalid tensor path keys:"
+                    " mixes dict and list on same layer"
+                )
+        if is_list:
+            # Lists are always ordered by the value of their key indices,
+            # rather than the order in the file.
+            list_layer = list(untyped_layer.items())
+            list_layer.sort(key=operator.itemgetter(0))
+            return [v for _, v in list_layer]
+        else:
+            return untyped_layer
+
+    # Track recursive state with a stack.
+    # Iterators track progress through the keys of each layer.
+    # Direct iterators over dictionaries (rather than just keys)
+    # may not be stable while actively mutating the dictionary
+    # mid-iteration, so the iterators are over a stable copy
+    # of the keys instead.
+    base_iter = iter(tuple(base))
+    layers = [(None, None, base, base_iter)]
+    while layers:
+        last_layer, last_key, layer, key_iterator = layers[-1]
+        for k in key_iterator:
+            next_layer = layer[k]
+            if isinstance(next_layer, dict):
+                # Recurse
+                next_iter = iter(tuple(next_layer))
+                layers.append((layer, k, next_layer, next_iter))
+                break
+        else:
+            # Update the key in the parent (or base) with the corrected type
+            re_typed = re_type_layer(layer)
+            if last_layer is None:
+                base = re_typed
+            else:
+                last_layer[last_key] = re_typed
+            layers.pop()
+    return base

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -12,6 +12,7 @@ import functools
 import hashlib
 import io
 import itertools
+import json
 import logging
 import operator
 import os
@@ -21,6 +22,7 @@ import stat
 import struct
 import threading
 import time
+import types
 import typing
 import weakref
 import zlib
@@ -60,6 +62,16 @@ from tensorizer._internal_utils import Chunked as _Chunked
 from tensorizer._internal_utils import _variable_read
 from tensorizer._NumpyTensor import _NumpyTensor
 
+__all__ = [
+    "TensorSerializer",
+    "TensorDeserializer",
+    "TensorType",
+    "CryptographyError",
+    "EncryptionParams",
+    "DecryptionParams",
+    "FilterFuncType",
+]
+
 
 @dataclasses.dataclass
 class _PerfStats:
@@ -81,21 +93,28 @@ _perf_stats = _PerfStats() if _enable_perf_stats else None
 
 lz4 = None
 
-__all__ = [
-    "TensorSerializer",
-    "TensorDeserializer",
-    "TensorType",
-    "CryptographyError",
-    "EncryptionParams",
-    "DecryptionParams",
-]
-
 # Setup logger
 logger = logging.getLogger(__name__)
 
 
 # Get CPU count
 cpu_count: int = _effective_cpu_count()
+
+
+class _SupportsBool(typing.Protocol):
+    def __bool__(self) -> bool: ...
+
+
+# Tensor paths are made up of strings (for mapping keys)
+# and integers (for array indices)
+_TensorPathComponent: "typing.TypeAlias" = Union[str, int]
+
+# Filter functions take either a single string (for a simple top-level dict key)
+# or a tensor path (a sequence of path components, each a string or integer).
+# Tensor paths are used for anything that is not a top-level string dict key.
+FilterFuncType: "typing.TypeAlias" = Callable[
+    [Union[str, Sequence[_TensorPathComponent]]], _SupportsBool
+]
 
 
 class CryptographyError(_crypt.CryptographyError):
@@ -170,6 +189,160 @@ class TensorHash:
     hash: bytes
 
 
+class _TensorPath(tuple):
+    def serialized_(self) -> bytes:
+        if self.is_str_:
+            return self[0].encode("utf-8")
+        else:
+            # application/json-seq format
+            return b"\x1e" + json.dumps(
+                self, indent=None, ensure_ascii=True, separators=(",", ":")
+            ).encode("ascii")
+
+    @property
+    def is_str_(self) -> bool:
+        return len(self) == 1 and isinstance(self[0], str)
+
+    def normalize_(self) -> Union[tuple, str]:
+        return self[0] if self.is_str_ else tuple(self)
+
+    def __str__(self) -> str:
+        return str(self.normalize_())
+
+    def append_(self, other: Union[str, int]) -> "_TensorPath":
+        if not isinstance(other, (str, int)):
+            raise TypeError(f"Invalid key type: {other.__class__.__name__!r}")
+        else:
+            return self.__class__(self + (other,))
+
+    def validate_(self) -> None:
+        if not self:
+            raise ValueError("Invalid empty tensor path")
+        for i in self:
+            if not isinstance(i, (str, int)):
+                raise TypeError(
+                    "Invalid tensor path component type:"
+                    f" {i.__class__.__name__!r}"
+                )
+            if isinstance(i, int) and i < 0:
+                raise ValueError(
+                    f"Invalid negative integer tensor path component: {i}"
+                )
+
+    @staticmethod
+    def _invalid_hook(*_args, **_kwargs):
+        raise TypeError("Invalid deserialized type")
+
+    @classmethod
+    def deserialize_(cls, serialized: typing.ByteString) -> "_TensorPath":
+        if not isinstance(serialized, (bytes, bytearray)):
+            raise TypeError(
+                "Invalid tensor path: expected byte string,"
+                f" got {serialized.__class__.__name__!r}"
+            )
+        if not serialized:
+            ret = cls()
+            ret.validate_()
+            return ret
+        first_byte: int = serialized[0]
+        if first_byte == 0x1E:
+            if (
+                len(serialized) < 3
+                or serialized[1] != 0x5B  # "["
+                or serialized[-1] != 0x5D  # "]"
+            ):
+                # Require the form <RS>[...]
+                raise ValueError("Invalid tensor path: non-array json-seq")
+            if 0x0A in serialized or 0x0D in serialized:
+                raise ValueError("Illegal newline in json-seq")
+            try:
+                deserialized: List[Union[str, int]] = json.loads(
+                    serialized[1:],
+                    object_hook=cls._invalid_hook,
+                    parse_float=cls._invalid_hook,
+                    parse_constant=cls._invalid_hook,
+                )
+            except RecursionError as e:
+                raise ValueError(
+                    "Cannot deserialize tensor path due to excessive nesting"
+                ) from e
+            if not isinstance(deserialized, list):
+                raise TypeError(
+                    "Invalid deserialized type:"
+                    " expected array as top level object"
+                )
+            ret = cls(deserialized)
+            ret.validate_()
+            return ret
+        else:
+            return cls((serialized.decode("utf-8"),))
+
+
+@dataclasses.dataclass
+class _TensorPathRegistry:
+    """
+    Tracks tensor paths used so far, throwing an error on prefix conflicts,
+    and building a prefix tree of layers of the nested structure.
+    """
+
+    __slots__ = "_registered_paths"
+    _registered_paths: dict
+
+    def __init__(self):
+        self._registered_paths = {}
+
+    def _check_compatible_types(self, path: _TensorPath) -> None:
+        branch = self._registered_paths
+        for depth, component in enumerate(path):
+            if not branch:
+                break
+            existing_type = type(next(iter(branch)))
+            current_type = type(component)
+            if existing_type is not current_type:
+                prefix: tuple = path[: depth + 1]
+                raise ValueError(
+                    "Conflicting tensor paths:"
+                    f" {path.normalize_()} has a different key type"
+                    f" ({current_type.__name__!r}) than existing keys at the"
+                    f" prefix {prefix} ({existing_type.__name__!r})"
+                )
+            if component not in branch:
+                break
+            branch = branch[component]
+
+    def register_path(self, path: Union[_TensorPath, str]) -> None:
+        branch: dict = self._registered_paths
+        if isinstance(path, str):
+            path = _TensorPath((path,))
+        if not isinstance(path, _TensorPath):
+            raise TypeError(
+                f"Invalid tensor path type: {path.__class__.__name__!r}"
+            )
+        if not path:
+            raise ValueError("Invalid empty tensor path")
+        self._check_compatible_types(path)
+        for component in path[:-1]:
+            branch = branch.setdefault(component, {})
+            if not isinstance(branch, dict):
+                raise ValueError(f"Conflicting tensor paths: {path}, {branch}")
+        component = path[-1]
+        if component in branch:
+            if isinstance(branch[component], dict):
+                raise ValueError(
+                    f"Conflicting tensor paths: {path.normalize_()} is both"
+                    " a leaf and a prefix of another path"
+                )
+            else:
+                raise ValueError(
+                    "Conflicting tensor paths:"
+                    f" {path.normalize_()} is used multiple times"
+                )
+        branch[component] = path
+
+    def dict(self) -> dict:
+        return self._registered_paths
+
+
 @dataclasses.dataclass(order=True)
 class TensorEntry:
     __slots__ = (
@@ -183,7 +356,7 @@ class TensorEntry:
         "hashes",
         "header_hashes",
     )
-    name: str
+    name: _TensorPath
     type: TensorType
     dtype: str
     shape: Tuple[int, ...]
@@ -549,7 +722,7 @@ class _TensorHeaderDeserializer:
     buffer: bytearray
     module_idx: int
     tensor_type: TensorType
-    name: str
+    name: _TensorPath
     dtype: str
     shape: Tuple[int, ...]
     hashes: List[TensorHash]
@@ -613,7 +786,12 @@ class _TensorHeaderDeserializer:
         # Read the name.
         name_slice, offset = self.read_name(buffer, offset)
         with name_slice:
-            self.name: str = str(name_slice, "utf-8")
+            self.name: _TensorPath = _TensorPath.deserialize_(bytes(name_slice))
+        if self.tensor_type != TensorType.STATE_DICT and not self.name.is_str_:
+            raise ValueError(
+                "Cannot deserialize structured tensor paths"
+                " from non-state-dicts"
+            )
 
         # Read the dtype of the tensor.
         dtype_slice, offset = self.read_dtype(buffer, offset)
@@ -750,31 +928,37 @@ class _MetadataDeserializer(dict):
     @classmethod
     def from_io(
         cls, reader: io.BufferedIOBase, count: int
-    ) -> Tuple["_MetadataDeserializer", bytes]:
+    ) -> Tuple["_MetadataDeserializer", dict, bytes]:
         raw = reader.read(cls._total_len_segment.size)
         total_len: int = cls._total_len_segment.unpack(raw)[0]
         if total_len == 0:
-            return cls(), raw
+            return cls(), {}, raw
         else:
             encoded_metadata: bytes = reader.read(total_len)
             raw += encoded_metadata
-            return cls.from_buffer(encoded_metadata, count), raw
+            return cls.from_buffer(encoded_metadata, count) + (raw,)
 
     @classmethod
-    def from_buffer(cls, buffer: bytes, count: int) -> "_MetadataDeserializer":
+    def from_buffer(
+        cls, buffer: bytes, count: int
+    ) -> Tuple["_MetadataDeserializer", dict]:
         offset = 0
         entries = cls()
+        registry = _TensorPathRegistry()
         for i in range(count):
-            entry, offset = cls._read_entry(buffer, offset)
+            entry, offset = cls._read_entry(buffer, offset, registry)
             entries[entry.name] = entry
-        return entries
+        return entries, registry.dict()
 
     @classmethod
-    def _read_entry(cls, buffer: bytes, offset: int) -> Tuple[TensorEntry, int]:
+    def _read_entry(
+        cls, buffer: bytes, offset: int, registry: _TensorPathRegistry
+    ) -> Tuple[TensorEntry, int]:
         # Read the name.
         name_slice, offset = cls._read_name(buffer, offset)
         with name_slice:
-            name: str = str(name_slice, "utf-8")
+            name: _TensorPath = _TensorPath.deserialize_(bytes(name_slice))
+            registry.register_path(name)
 
         tensor_type = TensorType(buffer[offset])
         offset += 1
@@ -1396,9 +1580,15 @@ class TensorDeserializer(
         file_obj: A file-like object to read from. It can also be a string
             representing a path to a file or an HTTP/HTTPS/S3 URI.
         device: The device to load the tensors to.
-        filter_func: A function (tensor_name: str) -> bool that returns True
+        filter_func: A function ``(tensor_name: str) -> bool`` that returns True
             if a tensor should be loaded, or False if it should be skipped.
             If None, all tensors are loaded.
+            For objects that were serialized from lists or nested mappings,
+            the tensor name will be given as a ``Sequence`` of path components
+            (each ``str`` or ``int``) for anything that is not a plain top-level
+            ``str`` key in the original serialized object. In this case,
+            the filter function should be compatible with the signature
+            ``(tensor_path: str | Sequence[str | int] -> bool)`` instead.
         dtype: The dtype to cast the tensors as when loading them into a torch
             module. If None, the dtype will be inferred from the file.
         lazy_load: If True, tensors will be loaded and cached when keys are
@@ -1474,7 +1664,7 @@ class TensorDeserializer(
             int,
         ],
         device: Optional[Union[torch.device, str]] = None,
-        filter_func: Optional[Callable[[str], Union[bool, Any]]] = None,
+        filter_func: Optional[FilterFuncType] = None,
         dtype: Optional[torch.dtype] = None,
         *,
         lazy_load: bool = False,
@@ -1557,7 +1747,7 @@ class TensorDeserializer(
 
             self._lazy_load: bool = lazy_load
 
-            self._metadata: Dict[str, TensorEntry] = {}
+            self._metadata: Dict[_TensorPath, TensorEntry] = {}
 
             # Read the magic
             magic = self._file.read(5)
@@ -1624,20 +1814,39 @@ class TensorDeserializer(
             # Read the metadata index of tensors.
             # This is a list of offsets into the file where the per-tensor data
             # is stored.
-            self._metadata: Dict[str, TensorEntry]
-            self._metadata, self._metadata_raw = _MetadataDeserializer.from_io(
-                self._file, self._file_header.tensor_count
+            self._metadata: Dict[_TensorPath, TensorEntry]
+            self._metadata, self._structure, self._metadata_raw = (
+                _MetadataDeserializer.from_io(
+                    self._file, self._file_header.tensor_count
+                )
             )
             if not self._metadata:
                 raise ValueError("Tensor index in the file is empty")
             # filter_func is a test that determines the tensor names to read.
             # If filter_func is None, all tensors are read.
             if filter_func is not None:
-                self._metadata: Dict[str, TensorEntry] = {
+                self._metadata = {
                     name: entry
                     for name, entry in self._metadata.items()
-                    if filter_func(name)
+                    if filter_func(name.normalize_())
                 }
+                # Remove keys from self._structure that aren't in self._metadata
+                structure = self._structure
+                structure_layers = [(structure, iter(tuple(structure)))]
+                while structure_layers:
+                    layer, layer_keys = structure_layers[-1]
+                    for k in layer_keys:
+                        v = layer[k]
+                        if isinstance(v, _TensorPath):
+                            # If this is a leaf, check if it needs to be pruned
+                            if v not in self._metadata:
+                                del layer[k]
+                        else:
+                            # Otherwise, recurse
+                            structure_layers.append((v, iter(tuple(v))))
+                            break
+                    else:
+                        structure_layers.pop()
 
             if not isinstance(num_readers, int):
                 raise TypeError(
@@ -1690,7 +1899,7 @@ class TensorDeserializer(
                 )
 
             self._keys_enumerated: Dict[str, int] = {
-                k: i for i, k in enumerate(self.keys())
+                k: i for i, k in enumerate(self._metadata.keys())
             }
 
             # The number of bytes we've allocated so far. Tensors may be read
@@ -1871,12 +2080,17 @@ class TensorDeserializer(
 
     _preload_cuda_called: ClassVar[bool] = False
 
-    def _read_single_tensor(self, expected_name: str) -> torch.nn.Parameter:
-        this_one_tensor_filter = partial(operator.eq, expected_name)
+    def _read_single_tensor(
+        self, expected_path: _TensorPath
+    ) -> torch.nn.Parameter:
+        expected_name: Union[tuple, str] = expected_path.normalize_()
+        this_one_tensor_filter: FilterFuncType = partial(
+            operator.eq, expected_name
+        )
         tensors = tuple(self.read_tensors(filter_func=this_one_tensor_filter))
         num_tensors = len(tensors)
         if num_tensors == 0:
-            raise RuntimeError("Tensor not found")
+            raise RuntimeError(f"Tensor not found: {expected_name!r}")
         elif num_tensors > 1:
             raise RuntimeError(
                 f"Found too many tensors: expected 1, found {num_tensors}"
@@ -1889,8 +2103,258 @@ class TensorDeserializer(
             )
         return tensor
 
-    def __getitem__(self, name) -> torch.nn.Parameter:
-        maybe_copied_data = self._cache.get(name)
+    @staticmethod
+    def _restructure(
+        flat: Dict[_TensorPath, torch.Tensor], use_dict_proxies: bool = False
+    ) -> Union[dict, list, types.MappingProxyType]:
+        for path in flat.keys():
+            if len(path) < 1:
+                raise ValueError("Invalid empty tensor path key")
+
+        # Start reconstructing everything as nested dictionaries
+        base = {}
+        for path, tensor in flat.items():
+            branch = base
+            for component in path[:-1]:
+                branch = branch.setdefault(component, {})
+                if not isinstance(branch, dict):
+                    # Key path conflicts should be caught at the metadata
+                    # parsing step, so this is just an extra sanity check
+                    raise RuntimeError(f"Key path conflict for key {path}")
+            component = path[-1]
+            if component in branch:
+                raise RuntimeError(f"Key path conflict for key {path}")
+            branch[component] = tensor
+
+        # Assign a type to each layer separately
+        def re_type_layer(
+            untyped_layer: dict,
+        ) -> Union[dict, list, types.MappingProxyType]:
+            if use_dict_proxies:
+                return types.MappingProxyType(untyped_layer)
+            is_list = False
+            for key in untyped_layer:
+                if isinstance(key, int):
+                    is_list = True
+                    if key < 0:
+                        raise ValueError(
+                            "Illegal negative integer tensor path component"
+                        )
+                elif is_list:
+                    raise ValueError(
+                        "Invalid tensor path keys:"
+                        " mixes dict and list on same layer"
+                    )
+            if is_list:
+                # Lists are always ordered by the value of their key indices,
+                # rather than the order in the file.
+                list_layer = list(untyped_layer.items())
+                list_layer.sort(key=operator.itemgetter(0))
+                return [v for _, v in list_layer]
+            else:
+                return untyped_layer
+
+        # Track recursive state with a stack.
+        # Iterators track progress through the keys of each layer.
+        # Direct iterators over dictionaries (rather than just keys)
+        # may not be stable while actively mutating the dictionary
+        # mid-iteration, so the iterators are over a stable copy
+        # of the keys instead.
+        base_iter = iter(tuple(base))
+        layers = [(None, None, base, base_iter)]
+        while layers:
+            last_layer, last_key, layer, key_iterator = layers[-1]
+            for k in key_iterator:
+                next_layer = layer[k]
+                if isinstance(next_layer, dict):
+                    # Recurse
+                    next_iter = iter(tuple(next_layer))
+                    layers.append((layer, k, next_layer, next_iter))
+                    break
+            else:
+                # Update the key in the parent (or base) with the corrected type
+                re_typed = re_type_layer(layer)
+                if last_layer is None:
+                    base = re_typed
+                else:
+                    last_layer[last_key] = re_typed
+                layers.pop()
+        return base
+
+    def _load_prefixed(
+        self,
+        prefix: Iterable[_TensorPathComponent],
+        use_dict_proxies: bool,
+        strip_prefix: bool = True,
+        filter_func: Optional[FilterFuncType] = None,
+    ) -> Union[dict, list, None]:
+        prefix: Tuple[_TensorPathComponent, ...] = tuple(prefix)
+        prefix_len: int = len(prefix)
+
+        keys = [
+            k
+            for k in self._metadata.keys()
+            if k[:prefix_len] == prefix
+            and (filter_func is None or filter_func(k.normalize_()))
+        ]
+        if not keys:
+            return None
+
+        with contextlib.closing(self._bulk_load(keys)) as loader:
+            unstructured: Dict[_TensorPath, torch.Tensor] = {}
+            for data in loader:
+                data: TensorDeserializer._CopiedData
+                unstructured[data.header.name] = data.parameter
+                del data
+
+        restructured = self._restructure(unstructured, use_dict_proxies)
+
+        if strip_prefix:
+            for i in range(prefix_len):
+                if not restructured:
+                    restructured = None
+                    break
+                elif isinstance(restructured, list):
+                    restructured = restructured[0]
+                else:
+                    restructured = restructured[prefix[i]]
+        return restructured
+
+    def tree(
+        self,
+        prefix: Optional[Iterable[_TensorPathComponent]] = None,
+        *,
+        default: Any = None,
+        filter_func: Optional[FilterFuncType] = None,
+    ) -> Union[typing.Mapping, Sequence, torch.Tensor, Any]:
+        """
+        Loads a (sub)tree of the serialized object's structure
+        as a mix of potentially-nested mappings and sequences,
+        or a leaf tensor. If no leaf tensors match the prefix,
+        `default` is returned.
+
+        Structures other than simple one-level mappings can be serialized via
+        ``TensorSerializer.write_state_dict``.
+
+        When accessing nested structures without this function
+        (e.g. when using ``__getitem__``), all layers are accessed as
+        read-only mappings instead of a mix of mappings and sequences.
+        In that scenario, sequences are represented as mappings with
+        integer keys instead of string keys.
+        This function, conversely, allows loading sequences as actual
+        ``Sequence`` type objects.
+
+        Args:
+            prefix: Path to a nested layer to load directly, as a sequence.
+                If ``None`` (the default) or an empty sequence, loads
+                all layers starting from the root.
+            default: Object to return if no leaf tensors match the prefix.
+            filter_func: An optional callable with the signature
+                ``(tensor_name: str | Sequence[str | int]) -> bool``
+                that takes the full path of each tensor in the subtree that
+                would be loaded, and can apply additional filtering logic to
+                decide whether each tensor should be loaded
+                on a per-tensor basis (more granular than a full subtree).
+                The function should return ``False`` to skip loading the tensor,
+                or ``True`` to load the tensor.
+                Note that the callable will always receive full tensor paths
+                relative to the root of the deserializer, including the
+                subtree's full prefix, if any.
+
+        Returns:
+            An object composed of potentially-nested mappings, sequences,
+            and tensors representing the subtree beginning at the specified
+            prefix.
+
+        Examples:
+            Serialize and deserialize nested objects::
+
+                serializer = TensorSerializer(path)
+                nested_structure = {
+                    "model": {
+                        "layer": [
+                            {"weight": torch.tensor(...)},
+                            {"weight": torch.tensor(...)},
+                        ],
+                    },
+                    "lm_head": torch.tensor(...),
+                }
+                serializer.write_state_dict(nested_structure)
+                serializer.close()
+
+                deserializer = TensorDeserializer(path)
+
+                # All the layers can be accessed as nested mappings
+                assert list(deserializer.keys()) == ["model", "lm_head"]
+                assert list(deserializer["model"].keys()) == ["layer"]
+
+                # Note: when accessed without .tree(),
+                # the list turns into a mapping with int keys
+                assert list(deserializer["model"]["layer"].keys()) == [0, 1]
+
+                assert list(
+                    deserializer["model"]["layer"][0].keys()
+                ) == ["weight"]
+
+                # The layers can be accessed with their
+                # original structure as well
+
+                from typing import Sequence, Mapping
+
+                tree = deserializer.tree()
+                assert isinstance(tree, Mapping)
+                assert isinstance(tree["model"]["layer"], Sequence)
+
+                # You can load the structure of a specific prefix
+                subtree = deserializer.tree(("model", "layer"))
+                assert isinstance(subtree, Sequence) and len(subtree) == 2
+
+            Serialize and deserialize a simple list::
+
+                serializer = TensorSerializer(path)
+                items = [
+                    torch.tensor(...), torch.tensor(...), torch.tensor(...)
+                ]
+                serializer.write_state_dict(items)
+                serializer.close()
+
+                deserializer = TensorDeserializer(path)
+
+                # The deserializer object is a mapping with int keys
+                # that resembles the original sequence
+                assert list(deserializer.keys()) == [0, 1, 2]
+                for i in range(3):
+                    print(deserializer[i].sum())
+                for tensor in deserializer.values():
+                    # Needs .values() to iterate over the contents
+                    print(tensor.sum())
+
+                # The result of deserializer.tree() is an actual sequence
+                from typing import Sequence
+                deserialized_sequence = deserializer.tree()
+                assert isinstance(deserialized_sequence, Sequence)
+                for i in range(3):
+                    print(deserialized_sequence[i].sum())
+                for tensor in deserialized_sequence:
+                    # Not a mapping; doesn't need .values()
+                    print(tensor.sum())
+        """
+        if prefix is None:
+            prefix = ()
+        if isinstance(prefix, (str, int)):
+            raise TypeError(
+                "Invalid prefix: expected sequence,"
+                f" got {prefix.__class__.__name__!r}"
+                " (for a single-element prefix, use a single-element sequence)"
+            )
+        prefixed = self._load_prefixed(
+            prefix, use_dict_proxies=False, filter_func=filter_func
+        )
+        return prefixed if prefixed is not None else default
+
+    def __getitem__(self, name) -> Union[torch.nn.Parameter, typing.Mapping]:
+        path: tuple = (name,)
+        maybe_copied_data = self._cache.get(path)
         if maybe_copied_data is not None:
             return maybe_copied_data.parameter
 
@@ -1898,10 +2362,15 @@ class TensorDeserializer(
         # tensor data and then convert it to a torch parameter. Most
         # of the time, access patterns are front to back, so seeking
         # forward in a stream works well even for HTTP/HTTPS streams.
-        if name in self._metadata:
-            return self._read_single_tensor(name)
-        else:
+        if name not in self._structure:
             raise KeyError(f"Tensor {name} not found")
+        branch = self._structure[name]
+        if isinstance(branch, _TensorPath):
+            return self._read_single_tensor(_TensorPath(path))
+        else:
+            return self._load_prefixed(
+                path, use_dict_proxies=True
+            ) or types.MappingProxyType({})
 
     # To implement collections.abc.Mapping, this class needs to define:
     # 1. __getitem__(key)
@@ -1937,13 +2406,13 @@ class TensorDeserializer(
 
     def __iter__(self):
         # iter() on a mapping returns an iterator of only keys
-        yield from self._metadata
+        yield from self._structure
 
     def __len__(self):
-        return len(self._metadata)
+        return len(self._structure)
 
     def __contains__(self, key: str):
-        return key in self._metadata
+        return key in self._structure
 
     def keys(self):
         # We override keys() because dict_keys can be slightly more efficient
@@ -1952,7 +2421,7 @@ class TensorDeserializer(
         # Technically this makes mapping.keys().mapping invalid on
         # Python 3.10+ but it is not intended to be supported anyway, so treat
         # it as not implemented.
-        return self._metadata.keys()
+        return self._structure.keys()
 
     def _verify_hashes(
         self,
@@ -2113,7 +2582,7 @@ class TensorDeserializer(
 
     def _read_numpytensors(
         self,
-        filter_func: Optional[Callable[[str], Union[bool, Any]]] = None,
+        filter_func: Optional[FilterFuncType] = None,
         num_tensors: int = -1,
         verify_hash: Optional[bool] = None,
     ) -> Iterator[_CopiedData]:
@@ -2144,12 +2613,14 @@ class TensorDeserializer(
             raise ValueError("num_tensors must be -1 or non-negative")
         elif num_tensors == 0:
             return
-        keys_to_read = self.keys()
+        keys_to_read = self._metadata.keys()
         if self._last_yielded_key is not None:
             start = self._keys_enumerated[self._last_yielded_key]
             keys_to_read = itertools.islice(keys_to_read, start + 1, None)
         if filter_func is not None:
-            keys_to_read = filter(filter_func, keys_to_read)
+            keys_to_read = (
+                k for k in keys_to_read if filter_func(k.normalize_())
+            )
         if num_tensors != -1:
             keys_to_read = itertools.islice(keys_to_read, num_tensors)
 
@@ -2159,7 +2630,7 @@ class TensorDeserializer(
 
     def read_tensors(
         self,
-        filter_func: Optional[Callable[[str], Union[bool, Any]]] = None,
+        filter_func: Optional[FilterFuncType] = None,
         num_tensors: int = -1,
         verify_hash: Optional[bool] = None,
     ) -> Iterator[Tuple[int, int, str, torch.Tensor]]:
@@ -2194,11 +2665,11 @@ class TensorDeserializer(
             verify_hash=verify_hash,
         )
         for data in copied_data:
-            yield data.header.module_idx, data.header.tensor_type, data.header.name, data.parameter
+            yield data.header.module_idx, data.header.tensor_type, data.header.name.normalize_(), data.parameter
 
     def read_numpy_arrays(
         self,
-        filter_func: Optional[Callable[[str], Union[bool, Any]]] = None,
+        filter_func: Optional[FilterFuncType] = None,
         num_tensors: int = -1,
         allow_raw_data: bool = False,
         verify_hash: Optional[bool] = None,
@@ -2304,7 +2775,7 @@ class TensorDeserializer(
                     f"with a datatype of {np_dtype}"
                 )
 
-            yield module_idx, tensor_type, name, arr, is_opaque, torch_dtype
+            yield module_idx, tensor_type, name.normalize_(), arr, is_opaque, torch_dtype
 
     def _to_torch_parameter(
         self, tensor: Union[torch.Tensor, torch.nn.Parameter]
@@ -2358,7 +2829,7 @@ class TensorDeserializer(
             raise IOError("IO closed, instantiate if you want to load again.")
 
         self._cache = OrderedDict()
-        keys = tuple(self.keys())
+        keys = tuple(self._metadata.keys())
         bulk_loader = self._bulk_load(keys)
         with contextlib.closing(bulk_loader):
             for _ in bulk_loader:
@@ -2371,14 +2842,18 @@ class TensorDeserializer(
         self._file.close()
 
     def _bulk_load(
-        self, keys: Iterable[str], verify_hash: Optional[bool] = None
+        self,
+        keys: Iterable[Union[str, _TensorPath]],
+        verify_hash: Optional[bool] = None,
     ) -> Generator[_CopiedData, None, None]:
         # For each key in keys, identify the ones that are not in self._cache,
         # and run those through _bulk_load_uncached.
         # Results are stored in self._cache
         # Results are then yielded in order with the keys provided
 
-        keys = list(keys)
+        keys: List[_TensorPath] = [
+            k if isinstance(k, _TensorPath) else _TensorPath((k,)) for k in keys
+        ]
         if len(set(keys)) != len(keys):
             raise ValueError("Keys must not have any duplicates")
 
@@ -2388,9 +2863,11 @@ class TensorDeserializer(
         remaining = list(map(self._cache.get, keys))
         # Also allow looking up entries by key
         # This would just use one dict if they had efficient .last() methods
-        indices: Dict[str, int] = {k: i for i, k in enumerate(keys)}
+        indices: Dict[_TensorPath, int] = {k: i for i, k in enumerate(keys)}
         # Begin loading any that are not already cached
-        uncached: List[str] = [k for k, v in zip(keys, remaining) if v is None]
+        uncached: List[_TensorPath] = [
+            k for k, v in zip(keys, remaining) if v is None
+        ]
         loader = self._bulk_load_uncached(uncached, verify_hash)
         with contextlib.closing(loader):
             while remaining:
@@ -2407,13 +2884,15 @@ class TensorDeserializer(
                     remaining[indices[key]] = self._cache[key] = item
 
     def _bulk_load_uncached(
-        self, keys: Sequence[str], verify_hash: Optional[bool] = None
+        self, keys: Sequence[_TensorPath], verify_hash: Optional[bool] = None
     ) -> Generator[_CopiedData, None, None]:
         if not keys:
             return
 
-        # Ensure all keys are present and in sorted order with self.keys()
-        # This will raise a KeyError if a requested key isn't in self.keys()
+        # Ensure all keys are present and in sorted
+        # order relative to self._metadata.keys().
+        # This will raise a KeyError if a requested key
+        # isn't in self._metadata.keys().
         keys = sorted(keys, key=self._keys_enumerated.__getitem__)
         if any(itertools.starmap(operator.eq, zip(keys, keys[1:]))):
             raise ValueError("Keys must not have any duplicates")
@@ -2551,7 +3030,7 @@ class TensorDeserializer(
                     shared_buffer_tensor.numpy().data.cast("B")
                 )
 
-            tensor_sizes_by_name: Dict[str, int] = {
+            tensor_sizes_by_name: Dict[_TensorPath, int] = {
                 t.name: t.deserialized_length for t in tensor_items
             }
 
@@ -2704,7 +3183,7 @@ class TensorDeserializer(
     def load_into_module(
         self,
         m: torch.nn.Module,
-        filter_func: Optional[Callable[[str], Union[bool, Any]]] = None,
+        filter_func: Optional[FilterFuncType] = None,
         verify_hash: Optional[bool] = None,
     ) -> int:
         """
@@ -2740,26 +3219,23 @@ class TensorDeserializer(
             modules[name] = module
 
         keys = tuple(
-            k for k in self.keys() if filter_func is None or filter_func(k)
+            k
+            for k in self._metadata.keys()
+            if filter_func is None or filter_func(k.normalize_())
         )
 
         tensor_ct = len(keys)
 
+        buffer_type = TensorType.BUFFER
+        param_type = TensorType.PARAM
+        state_dict_type = TensorType.STATE_DICT
+
         bulk_loader = self._bulk_load(keys, verify_hash=verify_hash)
         with contextlib.closing(bulk_loader):
             for copied_data in bulk_loader:
-                name = copied_data.header.name
-                tensor = copied_data.parameter
-
-                obj_path, attr = name.rsplit(".", 1)
-                module: torch.nn.Module = modules[obj_path]
-                entry = self._metadata[name]
-
-                if entry.type is TensorType.PARAM:
-                    module.register_parameter(attr, tensor)
-                elif entry.type is TensorType.BUFFER:
-                    module.register_buffer(attr, tensor)
-                elif entry.type is TensorType.STATE_DICT:
+                path: _TensorPath = copied_data.header.name
+                entry = self._metadata[path]
+                if entry.type is state_dict_type:
                     raise NotImplementedError(
                         "This was serialized using"
                         " TensorSerializer.write_state_dict(), so it cannot be"
@@ -2767,8 +3243,26 @@ class TensorDeserializer(
                         " Use the TensorDeserializer object directly as a"
                         " state_dict mapping instead."
                     )
-                else:
+                elif (
+                    entry.type is not buffer_type
+                    and entry.type is not param_type
+                ):
                     raise RuntimeError(f"Invalid tensor type: {entry.type}")
+                elif not path.is_str_:
+                    raise NotImplementedError(
+                        "Cannot deserialize structured tensor keys as a module;"
+                        " try using the TensorDeserializer directly"
+                        " as a state_dict mapping instead."
+                    )
+                tensor = copied_data.parameter
+                name: str = path.normalize_()
+                obj_path, attr = name.rsplit(".", 1)
+                module: torch.nn.Module = modules[obj_path]
+
+                if entry.type is param_type:
+                    module.register_parameter(attr, tensor)
+                elif entry.type is buffer_type:
+                    module.register_buffer(attr, tensor)
 
         self._file.close()
         return tensor_ct
@@ -2817,13 +3311,13 @@ class TensorDeserializer(
         # but aren't included in a state_dict() in PyTorch.
         modules.update(m.named_buffers())
 
-        for name in self.keys():
+        for path, entry in self._metadata.items():
+            name = path.normalize_()
             # Check if the module has this tensor.
             if name not in modules:
                 results.append((name, False))
                 continue
             module: torch.nn.Module = modules[name]
-            entry = self._metadata[name]
             if entry.hashes is None:
                 raise RuntimeError(
                     f"No hashes found in metadata for {name}. This is usually"
@@ -2867,21 +3361,23 @@ class TensorDeserializer(
         header_entry += self._metadata_raw
         redis_client.set(f"{key_prefix}:header:0", header_entry)
 
-        for name in self._metadata:
-            entry = self._metadata[name]
-            offset = self._metadata[name].offset
-            data_offset = self._metadata[name].data_offset
+        for name, entry in self._metadata.items():
+            offset = entry.offset
+            data_offset = entry.data_offset
             header_size = data_offset - offset
             self._file.seek(offset)
             header_entry = self._file.read(header_size)
             # Check if the key already exists
+            name_str: str = name.serialized_().decode("utf-8")
             if not force and redis_client.exists(
-                f"{key_prefix}:{name}:{offset}"
+                f"{key_prefix}:{name_str}:{offset}"
             ):
                 continue
-            redis_client.set(f"{key_prefix}:{name}:{offset}", header_entry)
+            redis_client.set(f"{key_prefix}:{name_str}:{offset}", header_entry)
             data_entry = self._file.read(entry.data_length)
-            redis_client.set(f"{key_prefix}:{name}:{data_offset}", data_entry)
+            redis_client.set(
+                f"{key_prefix}:{name_str}:{data_offset}", data_entry
+            )
 
 
 class TensorSerializer:
@@ -2988,6 +3484,7 @@ class TensorSerializer:
         else:
             self._crypt_chunk_size = None
             self._used_nonces = None
+        self._path_registry: _TensorPathRegistry = _TensorPathRegistry()
 
         # Get information about the file object's capabilities
         _fd_getter = getattr(self._file, "fileno", None)
@@ -3394,7 +3891,7 @@ class TensorSerializer:
     def _write_tensor(
         self,
         idx,
-        name,
+        name: Union[_TensorPath, str],
         tensor_type: TensorType,
         tensor: Union[torch.Tensor, numpy.ndarray],
         *,
@@ -3420,6 +3917,7 @@ class TensorSerializer:
                 Where in the file to write the tensor entry. If not specified,
                 writes starting at the current file offset.
         """
+        self._path_registry.register_path(name)
         if isinstance(tensor, torch.Tensor):
             shape: Sequence[int] = tensor.size()
             has_data: bool = not tensor.is_meta
@@ -3471,7 +3969,10 @@ class TensorSerializer:
                 f" buffer size of underlying memory ({tensor_memory.nbytes})"
                 f" doesn't match reported size ({tensor_size})"
             )
-        name_bytes = name.encode("utf-8")
+        if isinstance(name, str):
+            name_bytes: bytes = name.encode("utf-8")
+        else:
+            name_bytes: bytes = name.serialized_()
         dtype_bytes = dtype_name.encode("utf-8")
         if len(dtype_bytes) >= 256:
             raise ValueError("dtype name length should be less than 256")
@@ -3807,7 +4308,7 @@ class TensorSerializer:
 
     class _WriteSpec(typing.NamedTuple):
         idx: int
-        name: str
+        path: Union[_TensorPath, str]
         tensor_type: TensorType
         tensor: torch.Tensor
         callback: Optional[Callable]
@@ -3816,7 +4317,14 @@ class TensorSerializer:
         tensors = collections.deque(tensors)
         next_pos = self._file.tell()
         if _syscalls.has_fallocate() and self._fd:
-            size = sum(len(t.name) for t in tensors)
+            size = sum(
+                len(
+                    t.path.serialized_()
+                    if isinstance(t.path, _TensorPath)
+                    else t.path.encode("utf-8")
+                )
+                for t in tensors
+            )
             size += sum(
                 t.tensor.element_size()
                 * t.tensor.nelement()
@@ -3946,7 +4454,7 @@ class TensorSerializer:
                         callback = partial(setattr, module, name, None)
                     yield TensorSerializer._WriteSpec(
                         idx=idx,
-                        name=label,
+                        path=label,
                         tensor_type=tensor_type,
                         tensor=tensor,
                         callback=callback,
@@ -3989,30 +4497,187 @@ class TensorSerializer:
                 spec
                 for spec in all_tensors
                 if spec.tensor_type != TensorType.BUFFER
-                or spec.name in persistent
+                or spec.path in persistent
             )
 
         self._bulk_write(all_tensors)
 
-    def write_state_dict(self, state_dict: Dict):
+    @staticmethod
+    def _key_value_iterator(obj: Union[typing.Sequence, typing.Mapping]):
+        if isinstance(obj, typing.Mapping):
+            for k in obj.keys():
+                if not isinstance(k, str):
+                    raise TypeError(
+                        "Invalid key type for state_dict: expected str, got"
+                        f" {k.__class__.__name__!r}"
+                    )
+            return iter(obj.items())
+        elif isinstance(obj, typing.Sequence):
+            return enumerate(obj)
+        else:
+            raise TypeError(
+                "Cannot serialize type as part of a state_dict:"
+                f" {obj.__class__.__name__!r}"
+            )
+
+    @staticmethod
+    def _flatten_structure(
+        obj: Union[List, typing.Mapping], prefix: _TensorPath = _TensorPath()
+    ) -> Iterable[Tuple[_TensorPath, torch.Tensor]]:
+        iters: List[Tuple[_TensorPath, Iterator]] = [
+            (prefix, TensorSerializer._key_value_iterator(obj))
+        ]
+        while iters:
+            pre, it = iters[-1]
+            for name, item in it:
+                path: _TensorPath = pre.append_(name)
+                if isinstance(item, torch.Tensor):
+                    yield path, item
+                else:
+                    iters.append(
+                        (path, TensorSerializer._key_value_iterator(item))
+                    )
+                    break
+            else:
+                iters.pop()
+
+    def write_state_dict(self, state_dict: Union[Dict, List, Tuple]):
         """
         Write the state_dict to the file in Tensorizer format.
 
+        The values are accessed at deserialization time by using
+        a ``TensorDeserializer`` object as a mapping.
+
+        The object passed to this function can be a ``dict``, a ``list``,
+        or any combination of dictionaries and lists nested together,
+        as long as the dictionaries have only string keys, as in JSON.
+        Other recognized mapping and sequence types (like tuples)
+        are converted to dictionaries and lists.
+
+        All leaf values must be instances of ``torch.Tensor``.
+
+        When deserialized, the original structure of mappings and sequences
+        can be accessed via the ``TensorDeserializer.tree`` method,
+        or the ``TensorDeserializer`` can still be used as a mapping,
+        which will provide uniform access to all layers as read-only mapping
+        proxies, with either ``str`` or ``int`` keys, for mapping and sequence
+        layers, respectively.
+
         It is strongly recommended that you use write_module instead of
         this function, as it will also write out the parameter type,
-        allowing for zero-copy loading of the module with
-        TensorDeserializer.load_into_module.
+        and allow for zero-copy loading of the module with
+        ``TensorDeserializer.load_into_module``.
+
+        See Also:
+            `TensorDeserializer.tree`
+
+        Examples:
+            Serialize a normal state dict::
+
+                serializer = TensorSerializer(path)
+                state_dict = model.state_dict()
+                serializer.write_state_dict(state_dict)
+                serializer.close()
+
+                deserializer = TensorDeserializer(path)
+                assert deserializer.keys() == state_dict.keys()
+
+            Serialize any dictionary of tensors::
+
+                serializer = TensorSerializer(path)
+                state_dict = {
+                    "model.layer.0.weight": torch.tensor(...),
+                    "model.layer.1.weight": torch.tensor(...),
+                    "lm_head": torch.tensor(...),
+                }
+                serializer.write_state_dict(state_dict)
+                serializer.close()
+
+                deserializer = TensorDeserializer(path)
+                assert deserializer.keys() == state_dict.keys()
+
+            Serialize nested objects::
+
+                serializer = TensorSerializer(path)
+                nested_structure = {
+                    "model": {
+                        "layer": [
+                            {"weight": torch.tensor(...)},
+                            {"weight": torch.tensor(...)},
+                        ],
+                    },
+                    "lm_head": torch.tensor(...),
+                }
+                serializer.write_state_dict(nested_structure)
+                serializer.close()
+
+                deserializer = TensorDeserializer(path)
+
+                # All the layers can be accessed as nested mappings
+                assert list(deserializer.keys()) == ["model", "lm_head"]
+                assert list(deserializer["model"].keys()) == ["layer"]
+
+                # Note: when accessed without .tree(),
+                # the list turns into a mapping with int keys
+                assert list(deserializer["model"]["layer"].keys()) == [0, 1]
+
+                assert list(
+                    deserializer["model"]["layer"][0].keys()
+                ) == ["weight"]
+
+                # The layers can be accessed with their
+                # original structure as well
+
+                from typing import Sequence, Mapping
+
+                tree = deserializer.tree()
+                assert isinstance(tree, Mapping)
+                assert isinstance(tree["model"]["layer"], Sequence)
+
+                # You can load the structure of a specific prefix
+                subtree = deserializer.tree(("model", "layer"))
+                assert isinstance(subtree, Sequence) and len(subtree) == 2
+
+            Serialize a simple list::
+
+                serializer = TensorSerializer(path)
+                items = [
+                    torch.tensor(...), torch.tensor(...), torch.tensor(...)
+                ]
+                serializer.write_state_dict(items)
+                serializer.close()
+
+                deserializer = TensorDeserializer(path)
+
+                # The deserializer object is a mapping with int keys
+                # that resembles the original sequence
+                assert list(deserializer.keys()) == [0, 1, 2]
+                for i in range(3):
+                    print(deserializer[i].sum())
+                for tensor in deserializer.values():
+                    # Needs .values() to iterate over the contents
+                    print(tensor.sum())
+
+                # The result of deserializer.tree() is an actual sequence
+                from typing import Sequence
+                deserialized_sequence = deserializer.tree()
+                assert isinstance(deserialized_sequence, Sequence)
+                for i in range(3):
+                    print(deserialized_sequence[i].sum())
+                for tensor in deserialized_sequence:
+                    # Not a mapping; doesn't need .values()
+                    print(tensor.sum())
         """
         idx = 0
         self._bulk_write(
             TensorSerializer._WriteSpec(
                 idx=idx,
-                name=name,
+                path=name,
                 tensor_type=TensorType.STATE_DICT,
                 tensor=param,
                 callback=None,
             )
-            for name, param in state_dict.items()
+            for name, param in self._flatten_structure(state_dict)
         )
 
 


### PR DESCRIPTION
# Structured Object Serialization

This change adds serialization for structured objects in a way mirroring JSON.
`TensorSerializer.write_state_dict()` can now serialize nested dictionaries (or other mappings), nested lists (or other sequences), and arbitrary mixtures of dictionaries and lists. Nested structure is accessed at deserialization time either through repeated key lookup or the dedicated `TensorDeserializer.tree` method (open to other names).

## Usage

The usage is illustrated in the documentation for `TensorDeserializer.tree`:

```py
serializer = TensorSerializer(path)
nested_structure = {
    "model": {
        "layer": [
            {"weight": torch.tensor(...)},
            {"weight": torch.tensor(...)},
        ],
    },
    "lm_head": torch.tensor(...),
}
serializer.write_state_dict(nested_structure)
serializer.close()

deserializer = TensorDeserializer(path)

# All the layers can be accessed as nested mappings
assert list(deserializer.keys()) == ["model", "lm_head"]
assert list(deserializer["model"].keys()) == ["layer"]

# Note: when accessed without .tree(),
# the list turns into a mapping with int keys
assert list(deserializer["model"]["layer"].keys()) == [0, 1]

assert list(
    deserializer["model"]["layer"][0].keys()
) == ["weight"]

# The layers can be accessed with their
# original structure as well

from typing import Sequence, Mapping

tree = deserializer.tree()
assert isinstance(tree, Mapping)
assert isinstance(tree["model"]["layer"], Sequence)

# You can load the structure of a specific prefix
subtree = deserializer.tree(("model", "layer"))
assert isinstance(subtree, Sequence) and len(subtree) == 2
```

## Nested Structure Access

Accessing nested structures through direct key access always accesses them as (read-only) mappings, while the `TensorDeserializer.tree` method converts them to something matching their original type (`Sequence` or `Mapping`). The distinction is because it is possible to serialize a top-level sequence, but a `TensorDeserializer` is always a `Mapping` at its top level, and the `Mapping` and `Sequence` interfaces are not interchangeable. Additionally, mappings can have sparse integer keys (which aligns with the dynamics of a `filter_func`), while sequences must have sequential keys.

`TensorDeserializer` direct key access can only be done one path component at a time, and the `TensorDeserializer.keys()` method (and iterating over a `TensorDeserializer`) only returns top-level path components (i.e. the keys of the outermost structure). It does not walk the recursive structure. The behaviour of `TensorDeserializer.read_tensors()` is more like walking the structure, as it returns leaf tensors along with strings or tuples representing their full paths.

## Lazy, Eager, and Selective Loading

At the moment, the `TensorDeserializer.tree` method returns actual `dict` and `list` objects, and direct key access of a nested dictionary creates an actual `dict` and then makes it read-only by wrapping with a `types.MappingProxyType`. These are designed to be able to be changed to lazy view/proxy objects later, that can inherit `lazy_load` semantics from the `TensorDeserializer`. Subtrees are currently always (bulk-)loaded eagerly, and the `TensorDeserializer.tree` method exposes `prefix` and `filter_func` parameters to allow for more efficient selective loading.

As an extra interesting note, `TensorDeserializer.tree` is, as of this PR, the only function that allows non-stateful (unlike `.read_tensors()`) selective bulk loading *after initialization* for lazy-loaded deserializers, so it can also be used to effectively load multiple groups of keys from one lazy deserializer.

## Filter Functions

Filter functions have an extended signature when working with structured serialized tensors: `(tensor_path: str | Sequence[str | int]) -> bool`. Top-level `dict` string keys (previously the only keys possible for serialization and deserialization) are still given as single `str` objects, while any other structure (multiple components, or a single `int`) are always a `Sequence` of components. This allows writing filter functions like this:

```py
def filter_func(tensor_path) -> bool:
    # Load the key "thing", plus everything under the obj["array"][4]["subarray"] subtree
    if isinstance(tensor_path, str):
        return tensor_path == "thing"
    else:
        return tuple(tensor_path[:3]) == ("array", 4, "subarray")
```

Existing code that does not use structured serialization will only ever encounter plain `str` keys like before, so this is fully backwards-compatible.

Currently, `TensorDeserializer.load_into_module` does not support loading structured tensors. But since they can only be serialized by `TensorSerializer.write_state_dict`, which is incompatible with `TensorDeserializer.load_into_module` anyway, this is to be expected.

## Internal Format

Structured keys are stored as [`application/json-seq` (RFC 7464)](https://www.rfc-editor.org/rfc/rfc7464.html) arrays, which are single-line JSON arrays prefixed by a [`0x1E` ASCII record separator](https://www.compart.com/en/unicode/U+001E) character. There is no trailing newline required because arrays are self-delimited, as noted by RFC 7464. That is to say, the tensor accessed via `deserializer["a"]["b"]["c"][1][2][3]["x"]["y"]["z"]` would be encoded internally as a tensor named `\x1E["a","b","c",1,2,3,"x","y","z"]`.

The primary motivation for using `application/json-seq` as the format is that it provides both a straightforward indicator (in the form of a control character) that a field has special meaning and is to be parsed differently (as opposed to regular key names), has all the flexibility of JSON to represent arrays and mixed string and integer datatypes, is easily written and parsed with existing JSON libraries, is technically still an ASCII/UTF-8 string, so newer structured files can be opened with older deserializers (though without structure and the keys will look opaque), and it doesn't add significant size overhead, since most key data is already text, and wouldn't benefit from binary. Binary would still be preferable for parsing most integers, so future major revisions of the tensorizer format could implement a better custom list format while doing away with plain string key compatibility.

This is technically a breaking change for any tensor names that previously started with the control code `0x1E`, which seems acceptable.