### PR TITLE
feat(serialization): Use a dynamic `num_readers` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     make use of this parameter to increase deserialization speed
     - Files on the filesystem and HTTP(S) & S3 streams from
       `stream_io.open_stream` are eligible to be reopened this way
-  - The default is one sequential reader
+  - The default number of readers is dynamic based on the type of file used
+    - To disable concurrent readers, pass `num_readers=1` as a parameter
 - Structured object serialization ([#115])
   - `TensorSerializer.write_state_dict` can now write nested mappings,
     sequences, and other mixtures of mappings and sequences nested in each other

--- a/examples/deserialize.py
+++ b/examples/deserialize.py
@@ -10,14 +10,14 @@ from tensorizer import DecryptionParams, TensorDeserializer
 from tensorizer.utils import convert_bytes, get_mem_usage, no_init_or_tensor
 
 parser = argparse.ArgumentParser("deserialize")
-parser.add_argument("--source", default=None, help="local path or URL")
+parser.add_argument("--source", required=True, help="local path or URL")
 parser.add_argument("--model-ref", default="EleutherAI/gpt-j-6B")
 parser.add_argument("--no-plaid", action="store_true")
 parser.add_argument("--lazy-load", action="store_true")
 parser.add_argument("--verify-hash", action="store_true")
 parser.add_argument("--encryption", action="store_true")
 parser.add_argument("--viztracer", action="store_true")
-parser.add_argument("--num-readers", type=int, default=1)
+parser.add_argument("--num-readers", type=int, default=None)
 
 args = parser.parse_args()
 
@@ -25,9 +25,6 @@ model_ref = args.model_ref
 # To run this at home, swap this with the line below for a smaller example:
 # model_ref = "EleutherAI/gpt-neo-125M"
 model_name = model_ref.split("/")[-1]
-
-if args.source is None:
-    args.source = f"s3://{s3_bucket}/{model_name}.tensors"
 
 tracer = None
 if args.viztracer:

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -45,6 +45,7 @@ from typing import (
 )
 
 import numpy
+import psutil
 import redis
 import torch
 
@@ -1444,6 +1445,8 @@ class TensorDeserializer(
         plaid_mode: left for backwards compatibility; has no effect
         plaid_mode_buffers: left for backwards compatibility; has no effect
         num_readers: Number of threads from which to read the file_obj.
+            The default (None) uses a dynamic number of threads.
+            Set this value to 1 to disable concurrent reading.
         verify_hash: If True, the hashes of each tensor will be verified
             against the hashes stored in the metadata. A `HashMismatchError`
             will be raised if any of the hashes do not match.
@@ -1519,7 +1522,7 @@ class TensorDeserializer(
         plaid_mode_buffers: Optional[
             int
         ] = None,  # pylint: disable=unused-argument
-        num_readers: int = 1,
+        num_readers: Optional[int] = None,
         verify_hash: bool = False,
         encryption: Optional[DecryptionParams] = None,
     ):
@@ -1681,30 +1684,88 @@ class TensorDeserializer(
                 structure.filter(self._metadata.__contains__)
             self._structure: Dict[Union[str, int], Any] = structure.dict()
 
-            if not isinstance(num_readers, int):
+            dynamic_num_readers: bool = num_readers is None
+            if not dynamic_num_readers and not isinstance(num_readers, int):
                 raise TypeError(
-                    "num_readers: expected int,"
+                    "num_readers: expected int or None,"
                     f" got {num_readers.__class__.__name__}"
                 )
-            elif num_readers < 1:
+
+            if dynamic_num_readers:
+                if isinstance(
+                    getattr(self._file, "raw", self._file), io.FileIO
+                ):
+                    num_readers = 8
+                elif self._verify_hash:
+                    num_readers = 4
+                else:
+                    num_readers = 2
+                process = psutil.Process()
+                free_ram = (
+                    psutil.virtual_memory().free
+                    - process.memory_info().rss
+                    - sum(p.memory_info().rss for p in process.children(True))
+                )
+                del process
+                allowed_ram = free_ram - (10 << 20)
+                tensor_sizes = sorted(
+                    (t.deserialized_length for t in self._metadata),
+                    reverse=True,
+                )
+                num_readers = min(num_readers, len(tensor_sizes)) or 1
+                while (
+                    num_readers > 1
+                    and sum(tensor_sizes[:num_readers]) > allowed_ram
+                ):
+                    num_readers -= 1
+                del tensor_sizes
+
+            if num_readers < 1:
                 raise ValueError("num_readers must be positive")
             elif num_readers > len(self._metadata):
                 num_readers = len(self._metadata)
+
             if num_readers > 1:
                 self._reopen = self._reopen_func()
                 if self._reopen is None:
-                    raise ValueError(
-                        "Cannot reopen this type of file to enable"
-                        " parallel reading with num_readers > 1."
-                        " File paths, URIs, and HTTP(S) or S3"
-                        " streams returned from"
-                        " tensorizer.stream_io.open_stream,"
-                        " plus some open files are capable of being reopened."
-                        " Other file-like objects and special files"
-                        " (e.g. BytesIO, pipes, sockets) are not supported."
-                    )
+                    if dynamic_num_readers:
+                        num_readers = 1
+                    else:
+                        raise ValueError(
+                            "Cannot reopen this type of file to enable parallel"
+                            " reading with num_readers > 1. File paths, URIs,"
+                            " and HTTP(S) or S3 streams returned from"
+                            " tensorizer.stream_io.open_stream, plus some"
+                            " open files are capable of being reopened."
+                            " Other file-like objects and special files"
+                            " (e.g. BytesIO, pipes, sockets) are not supported."
+                        )
             else:
                 self._reopen = None
+
+            response_headers = getattr(self._file, "response_headers", None)
+            if (
+                num_readers > 1
+                and response_headers is not None
+                and response_headers.get("accept-ranges") != "bytes"
+            ):
+                # The server does not indicate support for range requests
+                if dynamic_num_readers:
+                    num_readers = 1
+                else:
+                    raise RuntimeError(
+                        "The server streaming the file to deserialize does not"
+                        " support HTTP range requests, necessary for"
+                        " parallel reading with num_readers > 1."
+                        " Set num_readers = 1,"
+                        " or use a different HTTP(S) endpoint."
+                    )
+            self._etag = (
+                None
+                if response_headers is None
+                else response_headers.get("etag") or None
+            )
+
             self._num_readers = num_readers
             self._reader_pool = concurrent.futures.ThreadPoolExecutor(
                 max_workers=num_readers,
@@ -2752,6 +2813,19 @@ class TensorDeserializer(
         try:
             if thread_idx != 0:
                 file_ = unsafe_self._reopen(begin=begin_offset, end=end_offset)
+
+                old_etag = unsafe_self._etag
+                if old_etag and hasattr(file_, "response_headers"):
+                    new_etag = file_.response_headers.get("etag") or None
+                    if new_etag is not None and new_etag != old_etag:
+                        # This might indicate that a different version of the
+                        # file was retrieved on the second attempt. ETag values
+                        # are not guaranteed to be stable for unchanged files,
+                        # though, so this isn't an error, just interesting info
+                        logger.info(
+                            "ETag in re-opened file doesn't match"
+                            f" (original: {old_etag}, new: {new_etag})"
+                        )
             else:
                 file_ = unsafe_self._file
                 file_.seek(begin_offset)

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -1701,15 +1701,7 @@ class TensorDeserializer(
                 else:
                     num_readers = 2
                 if is_cuda:
-                    process = psutil.Process()
-                    free_ram = (
-                        psutil.virtual_memory().free
-                        - process.memory_info().rss
-                        - sum(
-                            p.memory_info().rss for p in process.children(True)
-                        )
-                    )
-                    del process
+                    free_ram = psutil.virtual_memory().available
                     allowed_ram = free_ram - (10 << 20)
                     tensor_sizes = sorted(
                         (

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -1709,7 +1709,7 @@ class TensorDeserializer(
                 del process
                 allowed_ram = free_ram - (10 << 20)
                 tensor_sizes = sorted(
-                    (t.deserialized_length for t in self._metadata),
+                    (t.deserialized_length for t in self._metadata.values()),
                     reverse=True,
                 )
                 num_readers = min(num_readers, len(tensor_sizes)) or 1


### PR DESCRIPTION
# Multi-reader deserialization by default

This switches the default number of concurrent readers during deserialization from 1 to a dynamic value based on the file being  deserialized, and the system resources.

The logic to choose how many readers to use by default is:
- Anything that the code doesn't know how to reopen uses 1, otherwise,
- Local files use 8, otherwise,
- Anything using hash verification uses 4, otherwise,
- Anything else uses 2
- If a `CURLStreamFile`'s headers do not include `Accept-Ranges: bytes`, use 1
- Use fewer readers if the number picked is expected to overflow RAM
  - E.g. if only the top 4 largest tensors are expected to fit in memory at one time, don't default to more than 4 readers
  - This check is still bypassed if a specific `num_readers` is used
- Never use more readers than there are tensors in the file

An extra check is also added that reopened files have a matching [ETag](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag) to their original file, though it only emits a log statement if it fails (since ETags are not strictly guaranteed to be stable). This is because the initial reader could hypothetically fetch an older cached version of a resource when computing all the metadata, while subsequent readers get a newer version where their expected offsets are no longer valid. Since that would be a very confusing error if it comes up, a log statement could help figure it out.

This also pre-emptively raises an error if `num_readers` is specifically requested to be greater than 1 and the server does not give the `Accept-Ranges: bytes` header, where if `num_readers` is dynamic, it simply resets to 1.