### PR TITLE
fix(stream_io): Use exclusive end for `CURLStreamFile`s + misc bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `end` applies only to HTTP(S) & S3 streams, for which it is interpreted
       as the `start` and `end` parameters for the created `CURLStreamFile`
       object
-      - `end` is inclusive, like in an HTTP byte range request,
-        not one-past-the-end
 
 [#87]: https://github.com/coreweave/tensorizer/pull/87
 [#115]: https://github.com/coreweave/tensorizer/pull/115

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -2734,9 +2734,8 @@ class TensorDeserializer(
                 return
 
             begin_offset = tensor_items[0].offset
-            # End offsets for range requests include the final byte
             end_offset = (
-                tensor_items[-1].data_offset + tensor_items[-1].data_length - 1
+                tensor_items[-1].data_offset + tensor_items[-1].data_length
             )
         except Exception as e:
             barrier.abort()

--- a/tests/test_stream_io.py
+++ b/tests/test_stream_io.py
@@ -39,11 +39,39 @@ class TestCurlStream(unittest.TestCase):
         self.assertEqual(b"GPT Neo", stream.read(7))
 
     def test_curl_stream_end(self):
-        stream = stream_io.CURLStreamFile(NEO_URL, end=1)
+        stream = stream_io.CURLStreamFile(NEO_URL, end=2)
         self.assertEqual(b"# ", stream.read(5))
 
+    def test_curl_stream_begin_and_end(self):
+        stream = stream_io.CURLStreamFile(NEO_URL, begin=2, end=9)
+        self.assertEqual(b"GPT Neo", stream.read())
+        stream.close()
+
+        stream = stream_io.CURLStreamFile(NEO_URL, begin=2, end=9)
+        self.assertEqual(b"GPT Neo", stream.read(100))
+        stream.close()
+
+    def test_curl_stream_invalid_range(self):
+        test = self.subTest
+
+        def expect_err():
+            return self.assertRaises(ValueError)
+
+        with test("Invalid begin"), expect_err():
+            stream_io.CURLStreamFile(NEO_URL, begin=-1)
+        with test("Invalid end"), expect_err():
+            stream_io.CURLStreamFile(NEO_URL, end=-1)
+        with test("Invalid begin and end"), expect_err():
+            stream_io.CURLStreamFile(NEO_URL, begin=-2, end=-1)
+        with test("Backwards begin and end"), expect_err():
+            stream_io.CURLStreamFile(NEO_URL, begin=10, end=5)
+        with test("Equal begin and end"), expect_err():
+            stream_io.CURLStreamFile(NEO_URL, begin=5, end=5)
+        with test("End at zero (equals begin)"), expect_err():
+            stream_io.CURLStreamFile(NEO_URL, end=0)
+
     def test_curl_stream_buffer_end(self):
-        stream = stream_io.CURLStreamFile(NEO_URL, end=1)
+        stream = stream_io.CURLStreamFile(NEO_URL, end=2)
         ba = bytearray(5)
         self.assertEqual(2, stream.readinto(ba))
         self.assertEqual(b"# \x00\x00\x00", ba)


### PR DESCRIPTION
# Exclusive-end `CURLStreamFile` ranges

This change switches the `end` parameter for `CURLStreamFile`s and `open_stream` to mean one-past-the-end, since that matches Python slicing, and is what most Python programmers would expect.

Evidence for this is that our implementation of `CURLStreamFile.read()` and multi-reader deserialization were incorrect because even we all assumed the `end` parameter meant one-past-the-end while developing tensorizer until a bug arose with it during v2.9.0 development. The fix then was to make it match HTTP range behaviour of `end` being inclusive, but that is enough of an unintuitive footgun that it will very likely lead to more bugs later on.

It was also arguably a breaking change, as code already using `CURLStreamFile`s' `end` parameter had their behaviour change.

This PR also fixes bugs with `CURLStreamFile.__del__` on errors, and offset tracking when using `CURLStreamFile.read()` with no argument. It also adds more test cases verifying that invalid ranges raise errors correctly in the `CURLStreamFile` constructor.