### PR TITLE
[3.0-dev] Major refactor of serialization in prep for 3.0

### DIFF
--- a/tensorizer/_NumpyTensor.py
+++ b/tensorizer/_NumpyTensor.py
@@ -82,8 +82,6 @@ _DECODE_MAPPING = {
     k: v for k, v in _ALL_TYPES.items() if v not in _UNSUPPORTED_TYPES
 }
 
-OPAQUE_DTYPE_SEP = "\0"
-
 
 class _NumpyTensor(NamedTuple):
     data: numpy.ndarray
@@ -226,15 +224,6 @@ class _NumpyTensor(NamedTuple):
         """
         return self._is_opaque(self.numpy_dtype)
 
-    @property
-    def dtype_name(self):
-        if not self.is_opaque:
-            return self.numpy_dtype
-
-        # The datatype name needs to contain both the numpy dtype that the
-        # data is serialized as and the original torch dtype.
-        return self.numpy_dtype + OPAQUE_DTYPE_SEP + self.torch_dtype
-
     @staticmethod
     def _intermediate_type(size: int) -> torch.dtype:
         """
@@ -349,7 +338,3 @@ class _NumpyTensor(NamedTuple):
             raise ValueError(f"Invalid torch_dtype: {self.torch_dtype}") from e
 
         return dtype
-
-    @property
-    def tensor_memory(self):
-        return self.data.data

--- a/tensorizer/_NumpyTensor.py
+++ b/tensorizer/_NumpyTensor.py
@@ -82,6 +82,8 @@ _DECODE_MAPPING = {
     k: v for k, v in _ALL_TYPES.items() if v not in _UNSUPPORTED_TYPES
 }
 
+OPAQUE_DTYPE_SEP = "\0"
+
 
 class _NumpyTensor(NamedTuple):
     data: numpy.ndarray
@@ -224,6 +226,15 @@ class _NumpyTensor(NamedTuple):
         """
         return self._is_opaque(self.numpy_dtype)
 
+    @property
+    def dtype_name(self):
+        if not self.is_opaque:
+            return self.numpy_dtype
+
+        # The datatype name needs to contain both the numpy dtype that the
+        # data is serialized as and the original torch dtype.
+        return self.numpy_dtype + OPAQUE_DTYPE_SEP + self.torch_dtype
+
     @staticmethod
     def _intermediate_type(size: int) -> torch.dtype:
         """
@@ -338,3 +349,7 @@ class _NumpyTensor(NamedTuple):
             raise ValueError(f"Invalid torch_dtype: {self.torch_dtype}") from e
 
         return dtype
+
+    @property
+    def tensor_memory(self):
+        return self.data.data

--- a/tensorizer/_futuregroup.py
+++ b/tensorizer/_futuregroup.py
@@ -51,7 +51,13 @@ def _future_wait_and_raise(
     # Wait on a list of futures with a timeout. Raise any exceptions, including TimeoutErrors.
     # otherwise return the list of results in the same order as the input futures.
     results = []
-    fs = concurrent.futures.wait(futures, timeout=timeout)
+    flattened_futures = []
+    for f in futures:
+        if isinstance(f, _FutureGroup):
+            flattened_futures.extend(f.futures)
+        else:
+            flattened_futures.append(f)
+    fs = concurrent.futures.wait(flattened_futures, timeout=timeout)
     for f in fs.done:
         # if the future has an exception, this will raise it
         results.append(f.result())

--- a/tensorizer/_futuregroup.py
+++ b/tensorizer/_futuregroup.py
@@ -3,7 +3,7 @@ from typing import Any, List, Optional, Sequence, Union
 
 
 class _FutureGroup:
-    def __init__(self, futures: Sequence[concurrent.futures.Future]):
+    def __init__(self, futures):  # type: (Sequence[_Future]) -> None
         self.futures = futures
 
     def cancel(self) -> bool:

--- a/tensorizer/_futuregroup.py
+++ b/tensorizer/_futuregroup.py
@@ -1,0 +1,61 @@
+import concurrent.futures
+from collections.abc import Callable
+from typing import Any, Optional, Sequence
+
+
+class _FutureGroup(concurrent.futures.Future):
+    def __init__(self, futures: Sequence[concurrent.futures.Future]):
+        self.futures = futures
+
+    def cancel(self) -> bool:
+        result = True
+        for f in self.futures:
+            result = result and f.cancel()
+        return result
+
+    def cancelled(self) -> bool:
+        return all(f.cancelled() for f in self.futures)
+
+    def running(self) -> bool:
+        return any(f.running() for f in self.futures)
+
+    def done(self) -> bool:
+        return all(f.done() for f in self.futures)
+
+    def result(self, timeout=None) -> Sequence[Any]:
+        return _future_wait_and_raise(self.futures, timeout=timeout)
+
+    def exception(self, timeout=None) -> Optional[BaseException]:
+        for f in self.futures:
+            exc = f.exception(timeout=timeout)
+            if exc:
+                return exc
+        return None
+
+    def add_done_callback(self, _):
+        raise NotImplementedError()
+
+    def set_running_or_notify_cancel(self) -> bool:
+        raise NotImplementedError()
+
+    def set_result(self, _) -> None:
+        raise NotImplementedError()
+
+    def set_exception(self, _) -> None:
+        raise NotImplementedError()
+
+
+def _future_wait_and_raise(
+    futures: Sequence[concurrent.futures.Future], timeout=None
+) -> Sequence[Any]:
+    # Wait on a list of futures with a timeout. Raise any exceptions, including TimeoutErrors.
+    # otherwise return the list of results in the same order as the input futures.
+    results = []
+    fs = concurrent.futures.wait(futures, timeout=timeout)
+    for f in fs.done:
+        # if the future has an exception, this will raise it
+        results.append(f.result())
+    for f in fs.not_done:
+        # force raise of TimeoutError
+        results.append(f.result(0))
+    return results

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -4201,7 +4201,7 @@ class TensorSerializer:
             w.set_min_file_version_number(OPAQUE_TENSORIZER_VERSION)
 
     @staticmethod
-    def _do_clone(write_spec, dependency: Optional[concurrent.futures.Future]):
+    def _do_clone(write_spec, dependency: Optional[_Future]):
         if dependency is not None:
             dependency.result(_TIMEOUT)
         write_spec.tensor = write_spec.tensor.clone().detach()
@@ -4234,7 +4234,7 @@ class TensorSerializer:
                 ]
             )
 
-            clone_tasks = []
+            clone_tasks: List[_Future] = []
             for w in shared_write_specs[1:]:
                 clone_tasks.append(
                     self._computation_pool.submit(
@@ -4401,7 +4401,7 @@ class TensorSerializer:
         for w in write_specs:
             old_tensor_data_task = w.tensor_data_task
 
-            hash_tasks = []
+            hash_tasks: List[_Future] = []
             if w.include_crc32:
                 crc32_task = self._computation_pool.submit(
                     compute_crc32, w, old_tensor_data_task
@@ -4418,7 +4418,7 @@ class TensorSerializer:
                 self._jobs.extend(hash_tasks)
 
     def _do_encryption(self, write_specs: Sequence[_WriteSpec]) -> None:
-        def encrypt(write_spec, dependency: _Future):
+        def encrypt(write_spec, dependency: Optional[_Future]):
             if dependency is not None:
                 dependency.result(_TIMEOUT)
             try:

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -4201,6 +4201,7 @@ class TensorSerializer:
         if dependency is not None:
             dependency.result(_TIMEOUT)
         write_spec.tensor = write_spec.tensor.clone().detach()
+        write_spec.numpy_tensor = _NumpyTensor.from_tensor(write_spec.tensor)
 
     def _prepare_for_write_encryption(
         self, write_specs: Sequence[_WriteSpec]

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -3813,9 +3813,11 @@ class TensorSerializer:
         def set_min_file_version_number(self, version_number):
             self.min_file_version = max(self.min_file_version, version_number)
 
-    def _maybe_fallocate(self, tensors: Sequence[_WriteSpec]):
+    def _maybe_fallocate(
+        self, tensors: Sequence[_WriteSpec]
+    ) -> Optional[concurrent.futures.Future]:
         if not _syscalls.has_fallocate() or not self._fd:
-            return
+            return None
 
         next_pos = self._file.tell()
         size = sum(len(t.name.serialized_()) for t in tensors)
@@ -3828,16 +3830,21 @@ class TensorSerializer:
         # Rough underestimate of header size
         header_min_size = 24
         size += header_min_size * len(tensors)
-        _syscalls.try_fallocate(
-            self._fd, next_pos, size, suppress_all_errors=True
+
+        return self._header_writer_pool.submit(
+            _syscalls.try_fallocate,
+            self._fd,
+            next_pos,
+            size,
+            suppress_all_errors=True,
         )
 
     def _bulk_write(self, write_specs: Iterable[_WriteSpec], incremental=False):
         write_specs = list(write_specs)
 
+        write_dependency: Optional[concurrent.futures.Future] = None
         if not incremental:
-            # TODO: make into a future
-            self._maybe_fallocate(write_specs)
+            write_dependency = self._maybe_fallocate(write_specs)
 
         for w in write_specs:
             self._path_registry.register_path(w.name)
@@ -3854,6 +3861,9 @@ class TensorSerializer:
 
             if self._encrypted:
                 self._do_encryption(write_specs)
+            if write_dependency:
+                write_dependency.result(_TIMEOUT)
+
             self._do_commit_headers(write_specs)
             self._do_commit_tensor_data(write_specs)
             if self._encrypted:
@@ -4434,39 +4444,49 @@ class TensorSerializer:
             )
             self._jobs.append(w.tensor_data_task)
 
-    def _do_commit_headers(self, write_specs: Sequence[_WriteSpec]) -> None:
-        # TODO: this is lots of tiny writes. Buffer them for performance
-        def commit_header(write_spec, dependency: _Future):
-            if dependency is not None:
-                dependency.result(_TIMEOUT)
+    def _do_commit_headers(self, write_specs_: Sequence[_WriteSpec]) -> None:
+        def do_commit(
+            write_specs: Sequence[TensorSerializer._WriteSpec],
+            dependencies: Sequence[_Future],
+        ):
+
+            header_block_size = self._header_cur - self._metadata_start
+            header_buffer = bytearray(header_block_size)
+
+            metadata_start = self._metadata_start
+            metadata_size = (
+                self._metadata_cur - metadata_start - 8
+            )  # 8 bytes for metadata length field
+            struct.pack_into("<Q", header_buffer, 0, metadata_size)
+
+            _future_wait_and_raise(dependencies, _TIMEOUT)
+            for w in write_specs:
+                w_h = w.header
+                assert w_h is not None
+                # fmt: off
+                header_buffer[
+                    w.metadata_pos - metadata_start :
+                    w.metadata_pos + len(w_h.metadata_entry) - metadata_start
+                ] = w_h.metadata_entry
+                header_buffer[
+                    w_h.file_offset - metadata_start :
+                    w_h.file_offset + w_h.size - metadata_start
+                ] = w_h.buffer
+                # fmt: on
+
             self._pwrite(
-                write_spec.header.metadata_entry,
-                write_spec.metadata_pos,
-                verify=len(write_spec.header.metadata_entry),
-            )
-            self._pwrite(
-                write_spec.header.buffer,
-                write_spec.header.file_offset,
-                verify=write_spec.header.size,
+                header_buffer, metadata_start, verify=header_block_size
             )
 
-        metadata_size = (
-            self._metadata_cur - self._metadata_start - 8
-        )  # 8 bytes for metadata length field
-        metadata_size_task = self._header_writer_pool.submit(
-            self._pwrite,
-            struct.pack("<Q", metadata_size),
-            self._metadata_start,
-            verify=8,
+        deps = [
+            w.tensor_data_task
+            for w in write_specs_
+            if w.tensor_data_task is not None
+        ]
+        commit_header_task = self._header_writer_pool.submit(
+            do_commit, list(write_specs_), deps
         )
-        self._jobs.append(metadata_size_task)
-
-        for w in write_specs:
-            commit_header_task = self._header_writer_pool.submit(
-                commit_header, w, w.tensor_data_task
-            )
-            # Note this does _not_ set w.tensor_data_task, as committing headers is safe
-            self._jobs.append(commit_header_task)
+        self._jobs.append(commit_header_task)
 
     def _do_commit_tensor_data(self, write_specs: Sequence[_WriteSpec]):
         def commit_tensor_data(

--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -4,6 +4,7 @@
 ##############################################################################
 import abc
 import bisect
+import collections
 import collections.abc
 import concurrent.futures
 import contextlib
@@ -61,9 +62,10 @@ import tensorizer.utils as utils
 from tensorizer._crypt._cgroup_cpu_count import (
     effective_cpu_count as _effective_cpu_count,
 )
+from tensorizer._futuregroup import _future_wait_and_raise, _FutureGroup
 from tensorizer._internal_utils import Chunked as _Chunked
 from tensorizer._internal_utils import _variable_read
-from tensorizer._NumpyTensor import _NumpyTensor
+from tensorizer._NumpyTensor import OPAQUE_DTYPE_SEP, _NumpyTensor
 from tensorizer._tensor_path import (
     _TensorPath,
     _TensorPathComponent,
@@ -157,7 +159,9 @@ class TensorType(IntEnum):
 
 
 # Current version
-TENSORIZER_VERSION = 4
+TENSORIZER_VERSION = 5
+
+HEADERS_AT_TOP_TENSORIZER_VERSION = 5
 
 # To serialize meta tensors into metadata-only tensors
 # that deserialize back into zeroed-out buffers, data version 4 is required.
@@ -175,8 +179,6 @@ OPAQUE_TENSORIZER_VERSION = 2
 NON_OPAQUE_TENSORIZER_VERSION = 1
 
 TENSORIZER_MAGIC = b"|TZR|"
-
-OPAQUE_DTYPE_SEP = "\0"
 
 _TIMEOUT: typing.Final[int] = 3600
 
@@ -221,7 +223,9 @@ class TensorEntry:
         if self.data_length > 0:
             return self.data_length
         element_size: int = numpy.dtype(self.dtype).itemsize
-        num_elements: int = numpy.product(self.shape)
+        num_elements: int = int(
+            numpy.product(self.shape)
+        )  # numpy.product([]) == 1.0
         return element_size * num_elements
 
 
@@ -397,17 +401,27 @@ class _TensorHeaderSerializer:
         dtype: bytes,
         shape: Sequence[int],
         data_length: int,
-        file_offset: int,
+        file_offset: int,  # location of header in file
         include_crc32: bool = True,
         include_sha256: bool = True,
         crypt_info: Optional[_crypt_info.CryptInfo] = None,
     ):
+        self.module_index = module_index
+        self.tensor_type = tensor_type
+        self.name = name
+        self.shape = shape
+        self.dtype = dtype
+        self.data_length = data_length
+        self.file_offset = file_offset
+        self.include_crc32 = include_crc32
+        self.include_sha256 = include_sha256
+
         # Calculate the variable length segment
-        name_len = len(name)
-        dtype_len = len(dtype)
+        self.name_len = len(name)
+        self.dtype_len = len(dtype)
         # NB: shape_len is the number of dimensions,
         # not the encoded byte length
-        shape_len = len(shape)
+        self.shape_len = len(shape)
         self.crypt_info = crypt_info
         if crypt_info is None:
             crypt_info_len = 0
@@ -415,9 +429,9 @@ class _TensorHeaderSerializer:
             crypt_info_len = crypt_info.sized_size
         self.variable_length_segment = struct.Struct(
             self.variable_length_segment_template.format(
-                name_len=name_len,
-                dtype_len=dtype_len,
-                shape_len=shape_len,
+                name_len=self.name_len,
+                dtype_len=self.dtype_len,
+                shape_len=self.shape_len,
             )
         )
         crc32_len = sha256_len = self.hash_count = 0
@@ -438,7 +452,7 @@ class _TensorHeaderSerializer:
             self.sha256_hash_offset,
             self.crypt_info_offset,
             self.data_length_offset,
-            self.data_offset,
+            self.size,
         ) = itertools.accumulate(
             (
                 self.start_segment.size,
@@ -450,25 +464,28 @@ class _TensorHeaderSerializer:
                 self.data_length_segment.size,
             )
         )
-        self.size = self.data_offset
+
+    def build(self, tensor_data_offset: int):
+        # tensor_data_offset: location of tensor data in file
+        self.data_offset = tensor_data_offset
 
         self.buffer = bytearray(self.size)
         self.start_segment.pack_into(
             self.buffer,
             0,  # Offset
             self.size,  # Tensor header size
-            module_index,  # Module index.
-            tensor_type.value,  # Whether this is a parameter or a buffer
-            name_len,  # Parameter/buffer name length
+            self.module_index,  # Module index.
+            self.tensor_type.value,  # Whether this is a parameter or a buffer
+            self.name_len,  # Parameter/buffer name length
         )
         self.variable_length_segment.pack_into(
             self.buffer,
             self.variable_length_offset,
-            name,  # Parameter/buffer name UTF-8 bytes
-            dtype_len,  # Tensor dtype length
-            dtype,  # Tensor dtype UTF-8 bytes
-            shape_len,  # Tensor shape length
-            *shape,  # Tensor shape I array
+            self.name,  # Parameter/buffer name UTF-8 bytes
+            self.dtype_len,  # Tensor dtype length
+            self.dtype,  # Tensor dtype UTF-8 bytes
+            self.shape_len,  # Tensor shape length
+            *self.shape,  # Tensor shape I array
         )
 
         after_hashes = self.crypt_info_offset
@@ -481,46 +498,46 @@ class _TensorHeaderSerializer:
         )
 
         # Placeholders
-        if include_crc32:
+        if self.include_crc32:
             self.add_crc32(0)
-        if include_sha256:
+        if self.include_sha256:
             self.add_sha256(b"")
-        if crypt_info is not None:
-            crypt_info.sized_pack_into(self.buffer, self.crypt_info_offset)
+        if self.crypt_info is not None:
+            self.crypt_info.sized_pack_into(self.buffer, self.crypt_info_offset)
 
         self.data_length_segment.pack_into(
-            self.buffer, self.data_length_offset, data_length
+            self.buffer, self.data_length_offset, self.data_length
         )
 
-        metadata_entry_segment: struct.Struct = struct.Struct(
+        metadata_entry_segment = self.get_metadata_entry_segment()
+
+        self.metadata_entry = metadata_entry_segment.pack(
+            self.name_len,  # Name length
+            self.name,  # Name
+            self.tensor_type.value,  # Whether this is a parameter or a buffer
+            self.dtype_len,  # Dtype length
+            self.dtype,  # Dtype
+            self.shape_len,  # Shape length
+            *self.shape,  # Shape
+            self.file_offset,  # Header start (relative to the file)
+            # Tensor data start (relative to the file):
+            self.data_offset,
+            self.data_length,  # Tensor length
+        )
+
+    def get_metadata_entry_segment(self) -> struct.Struct:
+        return struct.Struct(
             self.metadata_entry_segment_template.format(
-                name_len=name_len,
-                dtype_len=dtype_len,
-                shape_len=shape_len,
+                name_len=self.name_len,
+                dtype_len=self.dtype_len,
+                shape_len=self.shape_len,
             )
         )
 
-        self.metadata_entry = metadata_entry_segment.pack(
-            name_len,  # Name length
-            name,  # Name
-            tensor_type.value,  # Whether this is a parameter or a buffer
-            dtype_len,  # Dtype length
-            dtype,  # Dtype
-            shape_len,  # Shape length
-            *shape,  # Shape
-            file_offset,  # Header start (relative to the file)
-            # Tensor data start (relative to the file):
-            file_offset + self.data_offset,
-            data_length,  # Tensor length
-        )
-
     def _hashable_segment_views(self):
-        if self.crypt_info is None:
-            yield memoryview(self.buffer)
-        else:
-            yield memoryview(self.buffer)[: self.crypt_info_offset]
-            # Skip crypt_info
-            yield memoryview(self.buffer)[self.data_length_offset :]
+        # Skip areas where we store hashes and crypt_info
+        yield memoryview(self.buffer)[: self.hash_header_offset]
+        yield memoryview(self.buffer)[self.data_length_offset :]
 
     def compute_crc32(self) -> int:
         crc32 = 0
@@ -652,6 +669,7 @@ class _TensorHeaderDeserializer:
         self.shape, offset = self.read_shape(buffer, offset)
 
         # Read our hashes in.
+        hash_start = offset
         hashes_slice, offset = self.read_hash_block(buffer, offset)
         with hashes_slice:
             self.hashes = self._decode_hashes(hashes_slice)
@@ -659,13 +677,8 @@ class _TensorHeaderDeserializer:
                 self._zero_hashes(hashes_slice)
 
         if check_crypt_info:
-            crypt_info_start = offset
             crypt_info_slice, offset = self.read_crypt_info_block(
                 buffer, offset
-            )
-            self._hashable_segments = (
-                slice(None, crypt_info_start),
-                slice(offset, None),
             )
             with crypt_info_slice:
                 self.crypt_info = _crypt_info.CryptInfo.unpack_from(
@@ -676,10 +689,14 @@ class _TensorHeaderDeserializer:
             self._hashable_segments = (slice(None, None),)
 
         # Finally, get the tensor data length.
-        offset = len(buffer) - self.data_length_segment.size
+        data_length_start = offset = len(buffer) - self.data_length_segment.size
         self.data_length = self.data_length_segment.unpack_from(buffer, offset)[
             0
         ]
+        self._hashable_segments = (
+            slice(None, hash_start),
+            slice(data_length_start, None),
+        )
 
     def _hashable_segment_views(self):
         for segment_slice in self._hashable_segments:
@@ -1656,13 +1673,6 @@ class TensorDeserializer(
                     "Tensor is encrypted, but decryption was not requested"
                 )
 
-            # The total size of the file.
-            # WARNING: this is not accurate. This field isn't used in the
-            # deserializer, but has been available as a public attribute,
-            # so it is kept how it was for compatibility until the next
-            # major version.
-            self.total_file_bytes = self._file_header.tensor_size
-
             # Read the metadata index of tensors.
             # This is a list of offsets into the file where the per-tensor data
             # is stored.
@@ -1674,6 +1684,30 @@ class TensorDeserializer(
             )
             if not self._metadata:
                 raise ValueError("Tensor index in the file is empty")
+
+            self._headers: Optional[
+                Dict[_TensorPath, _TensorHeaderDeserializer]
+            ]
+            if version_number >= HEADERS_AT_TOP_TENSORIZER_VERSION:
+                metadata_ordered = sorted(
+                    self._metadata.values(), key=operator.attrgetter("offset")
+                )
+                self._headers = {}
+                for entry in metadata_ordered:
+                    if self._file.tell() > entry.offset:
+                        raise ValueError("Header offsets overlap or are wrong")
+                    self._file.seek(entry.offset)
+                    header = _TensorHeaderDeserializer.from_io(
+                        self._file,
+                        zero_hashes=True,
+                        check_crypt_info=self._has_crypt_info,
+                    )
+                    if header is None:
+                        raise KeyError("Unexpected empty header")
+                    self._headers[entry.name] = header
+            else:
+                self._headers = None
+
             # filter_func is a test that determines the tensor names to read.
             # If filter_func is None, all tensors are read.
             if filter_func is not None:
@@ -2243,7 +2277,7 @@ class TensorDeserializer(
 
     def _verify_hashes(
         self,
-        name: str,
+        name: _TensorPath,
         hashes: Iterable[TensorHash],
         header_hashes: Dict[HashType, Any],
         mv: Union[memoryview, bytes],
@@ -2858,19 +2892,23 @@ class TensorDeserializer(
                 if halt:
                     break
 
-                header = _TensorHeaderDeserializer.from_io(
-                    file_,
-                    zero_hashes=True,
-                    check_crypt_info=unsafe_self._has_crypt_info,
-                )
+                if unsafe_self._headers is None:
+                    header = _TensorHeaderDeserializer.from_io(
+                        file_,
+                        zero_hashes=True,
+                        check_crypt_info=unsafe_self._has_crypt_info,
+                    )
+                    if header is None:
+                        raise KeyError("Unexpected empty header")
 
-                if header is None:
-                    raise ValueError("Unexpected empty header")
-
-                # Skip it if this tensor is not one we're supposed to load
-                if header.name not in tensor_sizes_by_name:
-                    file_.seek(header.data_length, io.SEEK_CUR)
-                    continue
+                    # Skip it if this tensor is not one we're supposed to load
+                    if header.name not in tensor_sizes_by_name:
+                        file_.seek(header.data_length, io.SEEK_CUR)
+                        continue
+                else:
+                    header = unsafe_self._headers[
+                        tensor_items[tensors_read].name
+                    ]
 
                 numpy_dtype, *torch_dtype = header.dtype.split(OPAQUE_DTYPE_SEP)
                 if not torch_dtype:
@@ -2934,6 +2972,7 @@ class TensorDeserializer(
 
                 if not is_meta:
                     start = time.perf_counter_ns() if _perf_stats else 0
+                    file_.seek(unsafe_self._metadata[header.name].data_offset)
 
                     if unsafe_self._encrypted and mv.nbytes > 0:
                         TensorDeserializer._stream_decrypt(
@@ -3266,6 +3305,7 @@ class TensorSerializer:
         *,
         encryption: Optional[EncryptionParams] = None,
         limit_cpu_concurrency: Optional[int] = None,
+        max_tensors: Optional[int] = None,
     ) -> None:
         if isinstance(file_obj, (str, bytes, os.PathLike, int)):
             self._file = stream_io.open_stream(file_obj, "wb+")
@@ -3415,16 +3455,7 @@ class TensorSerializer:
         self._write(TENSORIZER_MAGIC)
 
         # Write file header metadata
-        if not self._encrypted:
-            # Can't tell if OPAQUE_TENSORIZER_VERSION
-            # or META_TENSOR_TENSORIZER_VERSION are needed
-            # until a tensor is written later with an opaque dtype
-            # or from the meta device,
-            # so assume it is compatible with version 1 until then.
-            version_number = NON_OPAQUE_TENSORIZER_VERSION
-        else:
-            # File encryption requires a newer tensorizer version
-            version_number = ENCRYPTION_TENSORIZER_VERSION
+        version_number = HEADERS_AT_TOP_TENSORIZER_VERSION
         feature_flags = _FileFeatureFlags(0)
         if self._encrypted:
             feature_flags |= _FileFeatureFlags.encrypted
@@ -3437,14 +3468,26 @@ class TensorSerializer:
         )
         self._write(self._file_header.to_bytes())
 
-        # Reserve 256 KiB for metadata.
-        metadata_size = 256 * 1024
-        self._write(struct.pack("<Q", metadata_size))
-        self._metadata_loc = self._file.tell()
-        self._write(bytes(metadata_size))
-        self._flush()
-        self._metadata_cur = self._metadata_loc
-        self._metadata_end = self._metadata_loc + metadata_size
+        self._metadata_start = self._file.tell()
+        self._metadata_cur = (
+            self._metadata_start + 8
+        )  # position of next metadata entry we'd write. Leave 8 bytes for metadata length field
+        self._metadata_end: Optional[int] = None
+        self._header_end: Optional[int] = None
+        if max_tensors:
+            # Estimate 256 bytes per metadata entry and 1024 bytes per header entry
+            self._metadata_end = self._metadata_cur + max_tensors * 256
+            # this is less about header_end itself but ensuring that tensor_start is on a 4096-byte aligned boundary
+            self._header_end = (
+                (self._metadata_end + max_tensors * 1024) + 4095
+            ) & ~4095
+
+        self._header_cur = (
+            self._metadata_end
+        )  # is the start of where to write header data, or None
+        self._tensor_cur = (
+            self._header_end
+        )  # is the start of where to write tensor data. or None
 
     @property
     def total_tensor_bytes(self):
@@ -3464,23 +3507,19 @@ class TensorSerializer:
         and ensures that the file is in a consistent state.
 
         This must not be called while any I/O jobs are pending in
-        ``self._jobs``, as it is not thread-safe, and the contents of
-        ``self._file_header`` are only updated once each tensor writing job
-        finishes.
+        ``self._jobs``, as the contents of ``self._file_header``
+        are only updated once each tensor writing job finishes.
         """
-        curr = self._file.tell()
-
         # Write our zero-length field, that indicates that this is the last
         # tensor. This will be overwritten if another tensor is written.
-        self._write(struct.pack("<Q", 0))
+        self._pwrite(struct.pack("<Q", 0), self._tensor_cur)
 
         # Write our new file header.
-        self._file.seek(self._file_header_loc)
-        self._write(self._file_header.to_bytes())
+        self._pwrite(self._file_header.to_bytes(), self._file_header_loc)
 
         # Reset our file pointer to the end of the file,
         # minus the zero-length field.
-        self._file.seek(curr)
+        self._file.seek(self._tensor_cur)
         self._flush()
 
     def _pwrite(
@@ -3523,7 +3562,7 @@ class TensorSerializer:
         # run even between normal file writes.
         bytes_written: int = 0
         expected_bytes_written: int = (
-            verify if isinstance(verify, int) else self._buffer_size(data)
+            self._buffer_size(data) if isinstance(verify, bool) else verify
         )
         bytes_just_written: int = os.pwrite(self._fd, data, offset)
         bytes_written += bytes_just_written
@@ -3618,8 +3657,7 @@ class TensorSerializer:
             thread_pool.shutdown(wait=False)
 
     def _synchronize_pools(self):
-        for j in self._jobs:
-            j.result(timeout=_TIMEOUT)
+        _future_wait_and_raise(self._jobs, _TIMEOUT)
         self._jobs.clear()
         self._decryption_jobs.clear()
 
@@ -3671,9 +3709,8 @@ class TensorSerializer:
         tensor: Union[torch.Tensor, numpy.ndarray],
     ) -> None:
         """
-        Serializes a tensor, laying things out so that it can be read in three
-        calls from the input -- once for the size, once for the header, and
-        once for the tensor itself.
+        Serializes a tensor. Header data is appended to the metadata block at the top of the file, and
+        tensor data is appended to the bottom of the file.
 
         Args:
             idx: The index of the tensor in the module.
@@ -3684,6 +3721,7 @@ class TensorSerializer:
 
         Serialization format:
 
+         in header block near top of file:
          { uint64                           header_sz,
            uint16                           module_idx,
            uint8                            type,
@@ -3700,529 +3738,137 @@ class TensorSerializer:
               uint8                         hash_sz,
               []char                        hash_str,
              }                              hashes,
-           uint64                           tensor_sz,
-           []byte                           tensor }
+           uint64                           tensor_sz}
+           .....
+           affer all headers, bottom of file:
+           {[]byte                           tensor }
         """
-        self._write_tensor(
-            idx=idx, name=name, tensor_type=tensor_type, tensor=tensor
+        if isinstance(tensor, numpy.ndarray):
+            tensor = torch.from_numpy(tensor)
+
+        write_spec = self._WriteSpec(
+            module_index=idx, name=name, tensor_type=tensor_type, tensor=tensor
         )
+        self._bulk_write([write_spec], incremental=True)
 
-    def _write_tensor(
-        self,
-        idx,
-        name: Union[_TensorPath, str],
-        tensor_type: TensorType,
-        tensor: Union[torch.Tensor, numpy.ndarray],
-        *,
-        _synchronize: bool = True,
-        _start_pos: Optional[int] = None,
-        _temporary_buffer: bool = False,
-    ) -> int:
-        """
-        Underlying implementation for `write_tensor()`,
-        providing additional controls for asynchronous writes
-
-        Args:
-            idx: The index of the tensor in the module.
-            name: The name of the tensor.
-            tensor_type: The type of the tensor. This is used to determine
-                how to interpret the tensor.
-            tensor: The tensor to serialize.
-            _synchronize: Whether to synchronize metadata after writing
-                and ensure that all data is written to the file before
-                the call returns. If false, data may continue to be written
-                asynchronously even after this call returns.
-            _start_pos:
-                Where in the file to write the tensor entry. If not specified,
-                writes starting at the current file offset.
-        """
-        self._path_registry.register_path(name)
-        if isinstance(tensor, torch.Tensor):
-            shape: Sequence[int] = tensor.size()
-            has_data: bool = not tensor.is_meta
-            if has_data:
-                if not tensor.is_contiguous():
-                    _temporary_buffer = True
-                numpy_tensor = _NumpyTensor.from_tensor(tensor.contiguous())
-            else:
-                self._file_header.version_number = max(
-                    META_TENSOR_TENSORIZER_VERSION,
-                    self._file_header.version_number,
-                )
-                _temporary_buffer = True
-                hollow_tensor = torch.empty(
-                    (0,) * tensor.ndim, device="cpu", dtype=tensor.dtype
-                )
-                numpy_tensor = _NumpyTensor.from_tensor(hollow_tensor)
-        else:
-            shape: Sequence[int] = tensor.shape
-            has_data: bool = True
-            if (
-                isinstance(tensor, numpy.ndarray)
-                and not tensor.flags.c_contiguous
-                and hasattr(numpy, "ascontiguousarray")
-            ):
-                numpy_tensor = _NumpyTensor.from_array(
-                    numpy.ascontiguousarray(tensor)
-                )
-                _temporary_buffer = True
-            else:
-                numpy_tensor = _NumpyTensor.from_array(tensor)
-
-        dtype_name = numpy_tensor.numpy_dtype
-        if numpy_tensor.is_opaque:
-            # The datatype name needs to contain both the numpy dtype that the
-            # data is serialized as and the original torch dtype.
-            dtype_name += OPAQUE_DTYPE_SEP + numpy_tensor.torch_dtype
-            self._file_header.version_number = max(
-                OPAQUE_TENSORIZER_VERSION,
-                self._file_header.version_number,
-            )
-
-        tensor: numpy.ndarray = numpy_tensor.data
-        tensor_memory: memoryview = numpy_tensor.data.data
-        tensor_size: int = tensor.nbytes
-        if tensor_memory.nbytes != tensor_size:
-            raise ValueError(
-                f"Cannot serialize tensor {name!r}:"
-                f" buffer size of underlying memory ({tensor_memory.nbytes})"
-                f" doesn't match reported size ({tensor_size})"
-            )
-        if isinstance(name, str):
-            name_bytes: bytes = name.encode("utf-8")
-        else:
-            name_bytes: bytes = name.serialized_()
-        dtype_bytes = dtype_name.encode("utf-8")
-        if len(dtype_bytes) >= 256:
-            raise ValueError("dtype name length should be less than 256")
-        header_pos = self._file.tell() if _start_pos is None else _start_pos
-
-        encrypted: bool = self._encrypted and has_data
-        if encrypted:
-            chunks = _Chunked(
-                total_size=tensor_memory.nbytes,
-                chunk_size=self._crypt_chunk_size,
-            )
-            nonces = self._new_nonces(chunks.count)
-            encryptor = _crypt.ChunkedEncryption(
-                key=self._encryption.key,
-                buffer=tensor_memory,
-                chunk_size=self._crypt_chunk_size,
-                nonces=nonces,
-                executor=self._computation_pool,
-            )
-
-            key_derivation_chunk = self._encryption._crypt_info_chunk()
-            encryption_algorithm_chunk = _crypt_info.XSalsa20ParallelChunk(
-                chunk_size=self._crypt_chunk_size,
-                nonce=nonces[0],
-                macs=encryptor.macs,
-            )
-            if key_derivation_chunk is not None:
-                chunks = (key_derivation_chunk, encryption_algorithm_chunk)
-            else:
-                chunks = (encryption_algorithm_chunk,)
-            crypt_info = _crypt_info.CryptInfo(chunks)
-        else:
-            encryptor = None
-            if _FileFeatureFlags.encrypted in self._file_header.feature_flags:
-                # If the `encrypted` flag is present, all headers are expected
-                # to have crypt_info segments, so add an empty one
-                crypt_info = _crypt_info.CryptInfo()
-            else:
-                crypt_info = None
-
-        include_crc32: bool = not encrypted
-
-        header = _TensorHeaderSerializer(
-            idx,
-            tensor_type,
-            name_bytes,
-            dtype_bytes,
-            shape,
-            tensor_size,
-            header_pos,
-            include_crc32=include_crc32,
-            include_sha256=True,
-            crypt_info=crypt_info,
-        )
-
-        tensor_pos = header_pos + header.data_offset
-
-        # Add our tensor metadata to the index.
-        metadata = header.metadata_entry
-        # Check for overflow
-        if self._metadata_cur + len(metadata) > self._metadata_end:
-            raise RuntimeError("Metadata overflow")
-
-        metadata_pos = self._metadata_cur
-        metadata_len = len(metadata)
-        self._metadata_cur += metadata_len
-
-        # This task is I/O-bound and has no prerequisites,
-        # so it goes into the regular writer pool.
-        def write_metadata():
-            self._pwrite(metadata, metadata_pos, verify=metadata_len)
-
-        self._jobs.append(self._writer_pool.submit(write_metadata))
-
-        # Calculate the hashes.
-
-        # These two tasks are CPU-bound and don't block the GIL,
-        # so they go into the computation thread pool.
-        def compute_crc32(prerequisite: Optional[concurrent.futures.Future]):
-            if prerequisite is not None:
-                prerequisite.result(_TIMEOUT)
-            crc32 = header.compute_crc32()
-            return zlib.crc32(tensor_memory, crc32)
-
-        def compute_sha256(prerequisite: Optional[concurrent.futures.Future]):
-            if prerequisite is not None:
-                prerequisite.result(_TIMEOUT)
-            sha256 = header.compute_sha256()
-            sha256.update(tensor_memory)
-            return sha256.digest()
-
-        # This task is I/O-bound and dependent on the previous two tasks,
-        # so it goes into the header writer pool.
-        def commit_header(
-            crc32_future: Optional[concurrent.futures.Future],
-            sha256_future: Optional[concurrent.futures.Future],
-            encrypt_future: Optional[concurrent.futures.Future],
+    class _WriteSpec:
+        def __init__(
+            self,
+            module_index: int,
+            name: str | _TensorPath,
+            tensor_type: TensorType,
+            tensor: torch.Tensor,
         ):
-            crc32 = sha256 = None
-            if crc32_future is not None:
-                crc32 = crc32_future.result(_TIMEOUT)
-            if sha256_future is not None:
-                sha256 = sha256_future.result(_TIMEOUT)
-            if encrypt_future is not None:
-                encrypt_future.result(_TIMEOUT)
-            # These must be written only after all other futures complete
-            # to prevent a race condition from other threads hashing
-            # a partially-filled-in hash section
-            if crc32_future is not None:
-                header.add_crc32(crc32)
-            if sha256_future is not None:
-                header.add_sha256(sha256)
-            if encrypt_future is not None:
-                header.update_crypt_info()
-            self._pwrite(header.buffer, header_pos, verify=header.data_offset)
+            self.tensor = tensor
+            self.min_file_version = 0
+            self.user_owns_tensor_data = True
 
-        hash_tasks = []
-        if encrypted and not _temporary_buffer:
-            # If multiple tensors share memory, and were encrypted in-place,
-            # then this must not start hashing until any previous decryption
-            # tasks have restored this memory to its original state
-            mem_pointer = tensor.__array_interface__["data"][0]
-            pending_decryption = self._decryption_jobs.get(mem_pointer, None)
-        else:
-            mem_pointer = None
-            pending_decryption = None
-        if include_crc32:
-            crc32_task = self._computation_pool.submit(
-                compute_crc32, pending_decryption
+            # Every parameter to _TensorHeaderSerializer() exists as an attribute except self.file_offset
+            # defaulting to the simplest possible case:
+            #   CPU-based
+            #   contiguous
+            #   not hashing
+            #   not encrypted
+            #   not meta
+            #   not opaque
+            self.module_index = module_index
+            self.tensor_type: TensorType = tensor_type
+            self.name = _TensorPath.wrap_(name)
+            self.dtype: Optional[str] = None  # _prepare_for_write_numpy_tensor
+            self.shape = tensor.size()
+            self.data_length = tensor.nbytes
+            # self.file_offset  # intentionally omitted, handled by _write_headers()
+            self.include_crc32 = True
+            self.include_sha256 = True
+            self.crypt_info: Optional[_crypt_info.CryptInfo] = (
+                None  # _prepare_for_write_encryption
             )
-            hash_tasks.append(crc32_task)
-        else:
-            crc32_task = None
-        sha256_task = self._computation_pool.submit(
-            compute_sha256, pending_decryption
-        )
-        hash_tasks.append(sha256_task)
-        self._jobs.extend(hash_tasks)
 
-        def encrypt(prerequisites: Iterable[concurrent.futures.Future]):
-            fs = concurrent.futures.wait(prerequisites, timeout=_TIMEOUT)
-            for f in fs.done:
-                # Raise exceptions
-                f.result()
-            for f in fs.not_done:
-                # Raise timeouts
-                f.result(0)
-            try:
-                encryptor.encrypt_all(
-                    wait=True,
-                    timeout=_TIMEOUT,
-                )
-            except _crypt.CryptographyError as e:
-                raise CryptographyError("Tensor encryption failed") from e
+            # Additional payloads that get set and used during the prepare_for_write procedures
+            self.numpy_tensor: Optional[_NumpyTensor] = (
+                None  # $et in _prepare_for_write_numpy_tensor
+            )
+            self.header: Optional[_TensorHeaderSerializer] = (
+                None  # $et in _prepare_for_write_headers
+            )
+            self.metadata_pos = -1  # Set in _prepare_for_write_headers
+            self.encryptor: Optional[_crypt.ChunkedEncryption] = (
+                None  # $et in _do_encryption if encrypted
+            )
 
-        # This task is I/O-bound, so it goes into the regular writer pool.
-        def write_tensor_data(
-            prerequisite: Optional[concurrent.futures.Future], size: int
-        ):
-            if prerequisite is not None:
-                prerequisite.result(_TIMEOUT)
-            if has_data:
-                bytes_written = self._pwrite(
-                    tensor_memory, tensor_pos, verify=size
-                )
-            else:
-                bytes_written = 0
-            with self._tensor_count_update_lock:
-                self._file_header.tensor_count += 1
-                self._file_header.tensor_size += bytes_written
+            # self.tensor_data_task is a future for processing some contents of self.tensor
+            # e.g. cuda transfer, make_contiguous, hashing, encryption, writing, or decryption.
+            # They are often chained from one step of the process to the next
+            self.tensor_data_task: Optional[concurrent.futures.Future] = None
 
-        def decrypt(prerequisite: concurrent.futures.Future):
-            try:
-                prerequisite.result(_TIMEOUT)
-            finally:
-                # Try to decrypt again even if writing to disk failed
-                # to avoid exiting with the tensor memory in a modified state
-                fs = encryptor.decrypt_all(wait=False)
-                try:
-                    _crypt.ChunkedEncryption.wait_or_raise(
-                        fs,
-                        timeout=_TIMEOUT,
-                        return_when=concurrent.futures.ALL_COMPLETED,
-                    )
-                except _crypt.CryptographyError as e:
-                    try:
-                        original_exc = prerequisite.exception(timeout=0)
-                    except (
-                        concurrent.futures.TimeoutError,
-                        concurrent.futures.CancelledError,
-                    ):
-                        original_exc = None
-                    raise CryptographyError(
-                        "Restoring encrypted tensor data in memory failed"
-                    ) from (original_exc if original_exc is not None else e)
+        def set_min_file_version_number(self, version_number):
+            self.min_file_version = max(self.min_file_version, version_number)
 
-        # Encrypt the tensor memory in-place before writing
-        if encrypted:
-            encrypt_task = self._encryption_pool.submit(encrypt, hash_tasks)
-            self._jobs.append(encrypt_task)
-        else:
-            encrypt_task = None
+    def _maybe_fallocate(self, tensors: Sequence[_WriteSpec]):
+        if not _syscalls.has_fallocate() or not self._fd:
+            return
 
-        commit_header_task = self._header_writer_pool.submit(
-            commit_header, crc32_task, sha256_task, encrypt_task
-        )
-        self._jobs.append(commit_header_task)
-
-        # Write the potentially-encrypted tensor memory to the file
-        write_task = self._writer_pool.submit(
-            write_tensor_data, encrypt_task, tensor_size
-        )
-        self._jobs.append(write_task)
-        # Decrypt the memory after writing is finished, if it was encrypted
-        if encrypted and not _temporary_buffer:
-            decrypt_task = self._decryption_pool.submit(decrypt, write_task)
-            self._jobs.append(decrypt_task)
-            assert mem_pointer is not None
-            self._decryption_jobs[mem_pointer] = decrypt_task
-
-        tensor_endpos = tensor_pos + tensor_size
-
-        # Update our prologue.
-        if _synchronize:
-            self._synchronize_pools()
-            # Move to the end of our serialized tensor to prepare
-            # for the next one in the synchronized case.
-            self._file.seek(tensor_endpos)
-            self._sync_prologue_state()
-
-        ds_size = tensor_endpos - header_pos
-        ds_bytes = f"{ds_size:,} bytes"
-
-        typ = {
-            TensorType.PARAM: "p",
-            TensorType.BUFFER: "b",
-            TensorType.STATE_DICT: "sd",
-        }[tensor_type]
-
-        # if self.compress_tensors:
-        #     comp_report = (
-        #         f" - tensor:[raw: {tensor_raw_sz},"
-        #         + f" compressed: {tensor_compressed_sz},"
-        #         + f" ratio: {compression_ratio:.2f}]"
-        #     )
-        # else:
-        comp_report = ""
-        logger.debug(
-            f"{idx}:{typ}:{name} - {dtype_bytes.decode('utf-8')} - "
-            f"{tensor.shape} -> {ds_bytes}{comp_report}"
-        )
-        return tensor_endpos
-
-    @staticmethod
-    def _async_bulk_device_to_host_transfer(
-        tensors, max_read_ahead: Optional[int] = 32
-    ) -> Tuple[Iterator[torch.Tensor], Callable]:
-        """
-        Transfers CUDA tensors to host memory asynchronously in bulk.
-
-        Args:
-            tensors: The list of tensors to transfer.
-            max_read_ahead: The maximum number of tensors to queue.
-
-        Returns:
-            A tuple containing an iterator over CPU tensors,
-            and a callback to cancel the transfer early.
-        """
-        if len(tensors) < max_read_ahead:
-            transferred = queue.SimpleQueue()
-        else:
-            transferred = queue.Queue(maxsize=max_read_ahead)
-
-        tensor_sizes = [t.element_size() * t.nelement() for t in tensors]
-        staging_tensor = torch.empty(
-            (max(tensor_sizes),),
-            dtype=torch.uint8,
-            device="cpu",
-            pin_memory=True,
-        )
-
-        transfer_finished = False
-
-        def _transfer():
-            nonlocal transfer_finished
-            stream = torch.cuda.Stream()
-            with torch.cuda.stream(stream):
-                # This is in a separate CUDA stream because it shouldn't
-                # affect any other GPU operations, even though each
-                # of these transfers are synchronous
-                try:
-                    for t, nbytes in zip(tensors, tensor_sizes):
-                        if transfer_finished:
-                            break
-                        staging_tensor_view = (
-                            staging_tensor.narrow(0, 0, nbytes)
-                            .view(t.dtype)
-                            .view(t.shape)
-                        )
-                        staging_tensor_view.copy_(t)
-                        new_cpu_tensor = staging_tensor_view.clone()
-                        transferred.put(
-                            new_cpu_tensor.detach(),
-                            timeout=_TIMEOUT,
-                        )
-                finally:
-                    # Sentinel
-                    transferred.put(None)
-                    transfer_finished = True
-
-        transfer_thread = threading.Thread(
-            target=_transfer, name="TensorizerTransfer", daemon=True
-        )
-        transfer_thread.start()
-
-        def _interrupt_transfer():
-            nonlocal transfer_finished
-            if not transfer_finished:
-                # Signal the worker thread to end on its next loop
-                transfer_finished = True
-                try:
-                    # Unstick the worker thread so that
-                    # it isn't waiting for an open spot
-                    # that will never arrive
-                    transferred.get_nowait()
-                except queue.Empty:
-                    pass
-
-        return (
-            iter(lambda: transferred.get(timeout=_TIMEOUT), None),
-            _interrupt_transfer,
-        )
-
-    class _WriteSpec(typing.NamedTuple):
-        idx: int
-        path: Union[_TensorPath, str]
-        tensor_type: TensorType
-        tensor: torch.Tensor
-        callback: Optional[Callable]
-
-    def _bulk_write(self, tensors: Iterable[_WriteSpec]):
-        tensors = collections.deque(tensors)
         next_pos = self._file.tell()
-        if _syscalls.has_fallocate() and self._fd:
-            size = sum(
-                len(_TensorPath.wrap_(t.path).serialized_()) for t in tensors
-            )
-            size += sum(
-                t.tensor.element_size()
-                * t.tensor.nelement()
-                * (not t.tensor.is_meta)
-                for t in tensors
-            )
-            # Rough underestimate of header size
-            header_min_size = 24
-            size += header_min_size * len(tensors)
-            _syscalls.try_fallocate(
-                self._fd, next_pos, size, suppress_all_errors=True
-            )
+        size = sum(len(t.name.serialized_()) for t in tensors)
+        size += sum(
+            t.tensor.element_size()
+            * t.tensor.nelement()
+            * (not t.tensor.is_meta)
+            for t in tensors
+        )
+        # Rough underestimate of header size
+        header_min_size = 24
+        size += header_min_size * len(tensors)
+        _syscalls.try_fallocate(
+            self._fd, next_pos, size, suppress_all_errors=True
+        )
 
-        cuda_tensors = [
-            t.tensor for t in tensors if t.tensor.device.type == "cuda"
-        ]
-        if cuda_tensors:
-            (
-                transferred,
-                interrupt_transfer,
-            ) = self._async_bulk_device_to_host_transfer(cuda_tensors)
-        else:
-            transferred = interrupt_transfer = None
-        del cuda_tensors
+    def _bulk_write(self, write_specs: Iterable[_WriteSpec], incremental=False):
+        write_specs = list(write_specs)
 
-        if self._encrypted:
-            shared = []
-            seen_addresses = set()
-            for t in reversed(tensors):
-                if t.tensor.device.type in ("cuda", "meta"):
-                    shared.append(False)
-                else:
-                    address = t.tensor.data_ptr()
-                    shared.append(address in seen_addresses)
-                    seen_addresses.add(address)
-            del seen_addresses
-        else:
-            shared = [False] * len(tensors)
+        if not incremental:
+            # TODO: make into a future
+            self._maybe_fallocate(write_specs)
 
+        for w in write_specs:
+            self._path_registry.register_path(w.name)
+
+        cuda_executor = self._prepare_for_write_cuda(write_specs)
         try:
-            while tensors:
-                idx, name, tensor_type, tensor, callback = tensors.popleft()
-                is_shared = shared.pop()
-                self._idx = idx
-                if tensor.device.type == "cuda":
-                    tensor = next(transferred)
-                    temp_tensor = True
-                elif is_shared and self._encrypted:
-                    # Un-shares tensor memory in preparation for in-place
-                    # operations on the buffer that would otherwise conflict
-                    # with one another. Full support for shared-memory tensors
-                    # (e.g. if they were only written once) could make
-                    # this unnecessary, once implemented.
-                    # Another option would be to reuse the same encrypted
-                    # weights and decrypt them at the end. This would require
-                    # confirming that the tensor data regions are actually
-                    # identical, and don't just overlap.
-                    tensor = tensor.clone().detach()
-                    temp_tensor = True
-                else:
-                    temp_tensor = False
-                next_pos = self._write_tensor(
-                    idx,
-                    name,
-                    tensor_type,
-                    tensor,
-                    _synchronize=False,
-                    _start_pos=next_pos,
-                    _temporary_buffer=temp_tensor,
-                )
-                if callback is not None:
-                    callback()
-        except Exception:
-            if interrupt_transfer is not None:
-                interrupt_transfer()
-            raise
-        self._synchronize_pools()
-        self._file.seek(next_pos)
-        self._sync_prologue_state()
+            self._prepare_for_write_contiguous(write_specs)
+            self._prepare_for_write_meta(write_specs)
+            self._prepare_for_write_numpy_tensor(write_specs)
+            self._prepare_for_write_opaque(write_specs)
+            if self._encrypted:
+                self._prepare_for_write_encryption(write_specs)
+            self._prepare_for_write_headers(write_specs)
+            self._prepare_for_write_hashes(write_specs)
+
+            if self._encrypted:
+                self._do_encryption(write_specs)
+            self._do_commit_headers(write_specs)
+            self._do_commit_tensor_data(write_specs)
+            if self._encrypted:
+                self._maybe_decrypt_data(write_specs)
+
+            self._file_header.version_number = max(
+                self._file_header.version_number,
+                max(w.min_file_version for w in write_specs),
+            )
+
+            self._synchronize_pools()
+            self._sync_prologue_state()
+        except Exception as e:
+            if cuda_executor is not None:
+                cuda_executor.shutdown(wait=False, cancel_futures=True)
+            raise e
+
+        if cuda_executor is not None:
+            cuda_executor.shutdown(wait=True, cancel_futures=False)
 
     def write_module(
         self,
         m: torch.nn.Module,
-        remove_tensors: bool = False,
         *,
         include_non_persistent_buffers: bool = True,
     ) -> None:
@@ -4238,9 +3884,6 @@ class TensorSerializer:
 
         Args:
             m: The module to serialize.
-            remove_tensors: Whether to delete each tensor from `m`
-                after serializing it.
-                Deleted tensors are replaced with ``None``.
             include_non_persistent_buffers: Whether to serialize buffers
                 registered with ``persistent=False``.
                 Set to ``False`` to match the behaviour of
@@ -4251,10 +3894,9 @@ class TensorSerializer:
 
         modules = tuple(m.named_modules())
 
-        def extract_tensors():
+        def extract_tensors() -> Iterator[TensorSerializer._WriteSpec]:
             chain = itertools.chain
             repeat = itertools.repeat
-            callback = None
             for idx, (module_name, module) in enumerate(modules):
                 module: torch.nn.Module
                 parameters = module.named_parameters(recurse=False)
@@ -4264,14 +3906,11 @@ class TensorSerializer:
                     zip(buffers, repeat(TensorType.BUFFER)),
                 ):
                     label = f"{module_name}.{name}"
-                    if remove_tensors:
-                        callback = partial(setattr, module, name, None)
                     yield TensorSerializer._WriteSpec(
-                        idx=idx,
-                        path=label,
+                        module_index=idx,
+                        name=label,
                         tensor_type=tensor_type,
                         tensor=tensor,
-                        callback=callback,
                     )
 
         def persistent_buffers() -> Set[str]:
@@ -4311,7 +3950,7 @@ class TensorSerializer:
                 spec
                 for spec in all_tensors
                 if spec.tensor_type != TensorType.BUFFER
-                or spec.path in persistent
+                or str(spec.name) in persistent
             )
 
         self._bulk_write(all_tensors)
@@ -4446,16 +4085,449 @@ class TensorSerializer:
         idx = 0
         self._bulk_write(
             TensorSerializer._WriteSpec(
-                idx=idx,
-                path=name,
+                module_index=idx,
+                name=name,
                 tensor_type=TensorType.STATE_DICT,
                 tensor=param,
-                callback=None,
             )
             for name, param in _tensor_path.flatten_structure(
                 torch.Tensor, state_dict
             )
         )
+
+    def _prepare_for_write_cuda(
+        self, write_specs: Sequence[_WriteSpec]
+    ) -> Optional[concurrent.futures.ThreadPoolExecutor]:
+        cuda_specs = [w for w in write_specs if w.tensor.device.type == "cuda"]
+        if not cuda_specs:
+            return None
+
+        class CudaTransfer:
+            def __init__(self, max_size):
+                self.executor = concurrent.futures.ThreadPoolExecutor(
+                    max_workers=1,
+                    thread_name_prefix="TransferThread",
+                    initializer=self._allocate_staging_tensor,
+                    initargs=(max_size,),
+                )
+
+            def submit(self, write_spec) -> concurrent.futures.Future:
+                return self.executor.submit(self._transfer, write_spec)
+
+            def _allocate_staging_tensor(self, max_size: int):
+                self._stream = torch.cuda.Stream()
+                self._staging_tensor = torch.empty(
+                    (max_size,),
+                    dtype=torch.uint8,
+                    device="cpu",
+                    pin_memory=True,
+                )
+
+            def _transfer(self, write_spec):
+                nbytes = (
+                    write_spec.tensor.element_size()
+                    * write_spec.tensor.nelement()
+                )
+                staging_tensor_view = (
+                    self._staging_tensor.narrow(0, 0, nbytes)
+                    .view(write_spec.tensor.dtype)
+                    .view(write_spec.shape)
+                )
+                with torch.cuda.stream(self._stream):
+                    staging_tensor_view.copy_(write_spec.tensor)
+                write_spec.user_owns_tensor_data = False
+                write_spec.tensor = staging_tensor_view.clone().detach()
+
+        max_tensor_size = max(
+            [w.tensor.element_size() * w.tensor.nelement() for w in cuda_specs]
+        )
+        cuda_transfer = CudaTransfer(max_tensor_size)
+
+        for w in cuda_specs:
+            assert w.tensor_data_task is None
+            w.tensor_data_task = cuda_transfer.submit(w)
+
+        return cuda_transfer.executor
+
+    def _prepare_for_write_contiguous(self, write_specs: Sequence[_WriteSpec]):
+        def make_contiguous(write_spec, dependency):
+            if dependency is not None:
+                dependency.result(_TIMEOUT)
+            write_spec.tensor = write_spec.tensor.contiguous()
+            write_spec.data_length = write_spec.tensor.nbytes
+            write_spec.user_owns_tensor_data = False
+
+        for w in write_specs:
+            # if there is a tensor_data_task it is a cuda tensor
+            if w.tensor_data_task is not None or w.tensor.is_contiguous():
+                continue
+            w.tensor_data_task = self._computation_pool.submit(
+                make_contiguous, w, w.tensor_data_task
+            )
+
+    def _prepare_for_write_numpy_tensor(
+        self, write_specs: Sequence[_WriteSpec]
+    ):
+        for w in write_specs:
+            # all futures are resolved here. This step is not multi-threaded.
+            if w.tensor_data_task is not None:
+                w.tensor_data_task.result(_TIMEOUT)
+                w.tensor_data_task = None
+            w.numpy_tensor = _NumpyTensor.from_tensor(w.tensor)
+            w.dtype = w.numpy_tensor.numpy_dtype
+            if w.numpy_tensor.data.data.nbytes != w.tensor.nbytes:
+                raise ValueError(
+                    f"Cannot serialize tensor {w.name!r}:"
+                    f" buffer size of underlying memory ({w.numpy_tensor.data.data.nbytes})"
+                    f" doesn't match reported size ({w.tensor.nbytes})"
+                )
+
+    def _prepare_for_write_opaque(
+        self, write_specs: Sequence[_WriteSpec]
+    ) -> None:
+        for w in write_specs:
+            if not w.numpy_tensor.is_opaque:  # type: ignore
+                continue
+            # The datatype name needs to contain both the numpy dtype that the
+            # data is serialized as and the original torch dtype.
+            w.dtype += OPAQUE_DTYPE_SEP + w.numpy_tensor.torch_dtype  # type: ignore
+            w.set_min_file_version_number(OPAQUE_TENSORIZER_VERSION)
+
+    @staticmethod
+    def _do_clone(write_spec, dependency: Optional[concurrent.futures.Future]):
+        if dependency is not None:
+            dependency.result(_TIMEOUT)
+        write_spec.tensor = write_spec.tensor.clone().detach()
+
+    def _prepare_for_write_encryption(
+        self, write_specs: Sequence[_WriteSpec]
+    ) -> None:
+        assert self._encrypted and self._encryption is not None
+
+        # If any tensors are shared, so we need to clone all but one of them before encrypting
+        write_specs_by_addr: Dict[int, List[TensorSerializer._WriteSpec]] = (
+            collections.defaultdict(list)
+        )
+        for w in write_specs:
+            if w.tensor.device.type != "cpu":
+                continue
+            address = w.tensor.untyped_storage().data_ptr()
+            write_specs_by_addr[address].append(w)
+
+        for shared_write_specs in write_specs_by_addr.values():
+            if len(shared_write_specs) == 1:
+                continue
+
+            clone_dependencies = _FutureGroup(
+                [
+                    w.tensor_data_task
+                    for w in shared_write_specs
+                    if w.tensor_data_task is not None
+                ]
+            )
+
+            clone_tasks = []
+            for w in shared_write_specs[1:]:
+                clone_tasks.append(
+                    self._computation_pool.submit(
+                        self._do_clone, w, clone_dependencies
+                    )
+                )
+                w.user_owns_tensor_data = False
+
+            shared_write_specs[0].tensor_data_task = _FutureGroup(
+                clone_tasks + clone_dependencies.futures
+            )
+            for w in shared_write_specs[1:]:
+                w.tensor_data_task = _FutureGroup(clone_tasks)
+
+        for w in write_specs:
+            assert w.numpy_tensor is not None
+            w.include_crc32 = False
+
+            if w.data_length == 0:
+                # All headers are expected to have crypt_info segments, so add
+                # an empty one
+                w.crypt_info = _crypt_info.CryptInfo()
+                continue
+
+            if w.tensor_data_task is not None:
+                w.tensor_data_task.result(_TIMEOUT)
+                w.tensor_data_task = None
+
+            tensor_memory: memoryview = w.numpy_tensor.tensor_memory
+            chunked = _Chunked(
+                total_size=tensor_memory.nbytes,
+                chunk_size=self._crypt_chunk_size,
+            )
+            nonces = self._new_nonces(chunked.count)
+            w.encryptor = _crypt.ChunkedEncryption(
+                key=self._encryption.key,
+                buffer=tensor_memory,
+                chunk_size=self._crypt_chunk_size,
+                nonces=nonces,
+                executor=self._computation_pool,
+            )
+
+            key_derivation_chunk = self._encryption._crypt_info_chunk()
+            encryption_algorithm_chunk = _crypt_info.XSalsa20ParallelChunk(
+                chunk_size=self._crypt_chunk_size,
+                nonce=nonces[0],
+                macs=w.encryptor.macs,
+            )
+            chunks: Sequence[Any]
+            if key_derivation_chunk is not None:
+                chunks = (key_derivation_chunk, encryption_algorithm_chunk)
+            else:
+                chunks = (encryption_algorithm_chunk,)
+            w.crypt_info = _crypt_info.CryptInfo(chunks)
+
+    def _prepare_for_write_headers(
+        self, write_specs: Sequence[_WriteSpec]
+    ) -> None:
+        # We first need to construct the headers so that we know the size of each
+        for w in write_specs:
+            dtype_bytes = w.dtype.encode("utf-8")  # type: ignore
+            if len(dtype_bytes) >= 256:
+                raise ValueError("dtype name length should be less than 256")
+
+            w.header = _TensorHeaderSerializer(
+                w.module_index,
+                w.tensor_type,
+                w.name.serialized_(),  # name as bytes
+                dtype_bytes,
+                w.shape,
+                w.data_length,
+                0,  # bogus file_offset. This gets filled in in build()
+                include_crc32=w.include_crc32,
+                include_sha256=w.include_sha256,
+                crypt_info=w.crypt_info,
+            )
+
+        # Specify the offsets for each metadata entry
+        file_offset = (
+            self._metadata_cur
+        )  # position of next metadata entry to write
+
+        ## metadata
+        for w in write_specs:
+            w.metadata_pos = file_offset
+            file_offset += w.header.get_metadata_entry_segment().size
+
+        self._metadata_cur = file_offset
+        if self._metadata_end is None:
+            self._metadata_end = self._metadata_cur
+        elif file_offset > self._metadata_end:
+            raise RuntimeError("Metadata block is full. Increase max_tensors")
+
+        ## headers
+        if self._header_cur is not None:
+            if self._header_cur < file_offset:
+                raise RuntimeError("Somehow wrote past metadata block")
+            file_offset = self._header_cur
+
+        for w in write_specs:
+            w.header.file_offset = file_offset
+            file_offset += w.header.size
+
+        self._header_cur = file_offset
+        if self._header_end is None:
+            self._header_end = self._header_cur
+        elif self._header_cur > self._header_end:
+            raise RuntimeError("Header block is full. Increase max_tensors")
+
+        ## tensors
+        if self._tensor_cur is None:
+            # The block of tensor data starts on a page-aligned boundary
+            self._tensor_cur = (file_offset + 4095) & ~4095
+        else:
+            if self._tensor_cur < file_offset:
+                raise RuntimeError("Somehow wrote past header block")
+            # Each tensor itself begins on an 8-byte aligned boundary
+            file_offset = (self._tensor_cur + 7) & ~7
+
+        # file_offset is now where we should start writing tensor data
+        for w in write_specs:
+            w.header.build(file_offset)  # type: ignore
+            file_offset += w.data_length
+
+        self._tensor_cur = file_offset
+
+    def _prepare_for_write_meta(
+        self, write_specs: Sequence[_WriteSpec]
+    ) -> None:
+        for w in write_specs:
+            if not w.tensor.is_meta:
+                continue
+            w.tensor = torch.empty(
+                (0,) * w.tensor.ndim, device="cpu", dtype=w.tensor.dtype
+            )
+            w.data_length = 0
+            w.user_owns_tensor_data = False
+
+    def _prepare_for_write_hashes(
+        self, write_specs: Sequence[_WriteSpec]
+    ) -> None:
+        def compute_crc32(
+            write_spec: TensorSerializer._WriteSpec,
+            dependency: Optional[concurrent.futures.Future],
+        ):
+            if dependency is not None:
+                dependency.result(_TIMEOUT)
+            header_crc32 = write_spec.header.compute_crc32()
+            crc32 = zlib.crc32(
+                write_spec.numpy_tensor.tensor_memory, header_crc32
+            )
+            write_spec.header.add_crc32(crc32)
+
+        def compute_sha256(
+            write_spec: TensorSerializer._WriteSpec,
+            dependency: Optional[concurrent.futures.Future],
+        ):
+            if dependency is not None:
+                dependency.result(_TIMEOUT)
+            sha256 = write_spec.header.compute_sha256()
+            sha256.update(write_spec.numpy_tensor.tensor_memory)
+            write_spec.header.add_sha256(sha256.digest())
+
+        for w in write_specs:
+            old_tensor_data_task = w.tensor_data_task
+
+            hash_tasks = []
+            if w.include_crc32:
+                crc32_task = self._computation_pool.submit(
+                    compute_crc32, w, old_tensor_data_task
+                )
+                hash_tasks.append(crc32_task)
+            if w.include_sha256:
+                sha256_task = self._computation_pool.submit(
+                    compute_sha256, w, old_tensor_data_task
+                )
+                hash_tasks.append(sha256_task)
+
+            if hash_tasks:
+                w.tensor_data_task = _FutureGroup(hash_tasks)
+                self._jobs.extend(hash_tasks)
+
+    def _do_encryption(self, write_specs: Sequence[_WriteSpec]) -> None:
+        def encrypt(write_spec, dependency):
+            if dependency is not None:
+                dependency.result(_TIMEOUT)
+            try:
+                write_spec.encryptor.encrypt_all(wait=True, timeout=_TIMEOUT)
+            except _crypt.CryptographyError as e:
+                raise CryptographyError("Tensor encryption failed") from e
+            write_spec.header.update_crypt_info()
+
+        for w in write_specs:
+            if not w.data_length:
+                continue
+            w.tensor_data_task = self._encryption_pool.submit(
+                encrypt, w, w.tensor_data_task
+            )
+            self._jobs.append(w.tensor_data_task)
+
+    def _do_commit_headers(self, write_specs: Sequence[_WriteSpec]) -> None:
+        # TODO: this is lots of tiny writes. Buffer them for performance
+        def commit_header(write_spec, dependency):
+            if dependency is not None:
+                dependency.result(_TIMEOUT)
+            self._pwrite(
+                write_spec.header.metadata_entry,
+                write_spec.metadata_pos,
+                verify=len(write_spec.header.metadata_entry),
+            )
+            self._pwrite(
+                write_spec.header.buffer,
+                write_spec.header.file_offset,
+                verify=write_spec.header.size,
+            )
+
+        metadata_size = (
+            self._metadata_cur - self._metadata_start - 8
+        )  # 8 bytes for metadata length field
+        metadata_size_task = self._header_writer_pool.submit(
+            self._pwrite,
+            struct.pack("<Q", metadata_size),
+            self._metadata_start,
+            verify=8,
+        )
+        self._jobs.append(metadata_size_task)
+
+        for w in write_specs:
+            commit_header_task = self._header_writer_pool.submit(
+                commit_header, w, w.tensor_data_task
+            )
+            # Note this does _not_ set w.tensor_data_task, as committing headers is safe
+            self._jobs.append(commit_header_task)
+
+    def _do_commit_tensor_data(self, write_specs: Sequence[_WriteSpec]):
+        def commit_tensor_data(
+            write_spec: TensorSerializer._WriteSpec,
+            dependency: Optional[concurrent.futures.Future],
+        ):
+            if dependency is not None:
+                dependency.result(_TIMEOUT)
+            if write_spec.header.data_length == 0:
+                bytes_written = 0
+            else:
+                bytes_written = self._pwrite(
+                    write_spec.numpy_tensor.tensor_memory,
+                    write_spec.header.data_offset,  # type: ignore
+                    verify=write_spec.header.data_length,  # type: ignore
+                )
+
+            with self._tensor_count_update_lock:  # TODO: get rid of this?
+                self._file_header.tensor_count += 1
+                self._file_header.tensor_size += bytes_written
+
+        for w in write_specs:
+            w.tensor_data_task = self._writer_pool.submit(
+                commit_tensor_data, w, w.tensor_data_task
+            )
+            self._jobs.append(w.tensor_data_task)
+
+    def _maybe_decrypt_data(self, write_specs: Sequence[_WriteSpec]):
+        def decrypt(
+            write_spec: TensorSerializer._WriteSpec,
+            dependency: Optional[concurrent.futures.Future],
+        ):
+            try:
+                if dependency is not None:
+                    dependency.result(_TIMEOUT)
+            finally:
+                # Try to decrypt again even if writing to disk failed
+                # to avoid exiting with the tensor memory in a modified state
+                fs = write_spec.encryptor.decrypt_all(wait=False)  # type: ignore
+                try:
+                    _crypt.ChunkedEncryption.wait_or_raise(
+                        fs,
+                        timeout=_TIMEOUT,
+                        return_when=concurrent.futures.ALL_COMPLETED,
+                    )
+                except _crypt.CryptographyError as e:
+                    try:
+                        original_exc = (
+                            dependency.exception(timeout=0)
+                            if dependency is not None
+                            else None
+                        )
+                    except (
+                        concurrent.futures.TimeoutError,
+                        concurrent.futures.CancelledError,
+                    ):
+                        original_exc = None
+                    raise CryptographyError(
+                        "Restoring encrypted tensor data in memory failed"
+                    ) from (original_exc if original_exc is not None else e)
+
+        for w in write_specs:
+            if not w.user_owns_tensor_data:
+                continue
+            w.tensor_data_task = self._decryption_pool.submit(
+                decrypt, w, w.tensor_data_task
+            )
+            self._jobs.append(w.tensor_data_task)
 
 
 def _get_perf_stats():

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -811,6 +811,113 @@ class TestSerialization(unittest.TestCase):
                     self.assertNotIn("11", deserialized)
 
 
+class TestIncrementalSerialization(unittest.TestCase):
+    # Tests that involve multiple calls to write_tensor()
+
+    def test_too_many_no_max_tensors(self):
+        # Any attempt to call write_tensor() more than once will fail if you haven't specified max_tensors
+        with tempfile.NamedTemporaryFile(
+            "wb+", delete=True, delete_on_close=False
+        ) as temporary_file:
+            serializer = TensorSerializer(temporary_file)
+            serializer.write_tensor(
+                0,
+                "a",
+                TensorType.PARAM,
+                torch.zeros((64, 64), dtype=torch.uint8),
+            )
+            with self.assertRaises(RuntimeError):
+                serializer.write_tensor(
+                    1,
+                    "b",
+                    TensorType.PARAM,
+                    torch.zeros((64, 64), dtype=torch.uint8),
+                )
+
+    def test_too_many(self):
+        # If you set max_tensors too low you'll eventually run out of header space
+        with tempfile.NamedTemporaryFile(
+            "wb+", delete=True, delete_on_close=False
+        ) as temporary_file:
+            serializer = TensorSerializer(temporary_file, max_tensors=2)
+            last_success = 0
+            with self.assertRaises(RuntimeError):
+                for x in range(100):
+                    serializer.write_tensor(
+                        x,
+                        f"t.{x}",
+                        TensorType.PARAM,
+                        torch.zeros((64, 64), dtype=torch.uint8),
+                    )
+                    last_success = x
+            self.assertGreaterEqual(last_success, 2)
+
+    def test_long_tensor_name(self):
+        # Tensors with very long names could still cause space problems even if max_tensors is correct
+        with tempfile.NamedTemporaryFile(
+            "wb+", delete=True, delete_on_close=False
+        ) as temporary_file:
+            serializer = TensorSerializer(temporary_file, max_tensors=2)
+            serializer.write_tensor(
+                0,
+                "a",
+                TensorType.PARAM,
+                torch.zeros((64, 64), dtype=torch.uint8),
+            )
+            with self.assertRaises(RuntimeError):
+                serializer.write_tensor(
+                    0,
+                    "b" * 8192,
+                    TensorType.PARAM,
+                    torch.zeros((64, 64), dtype=torch.uint8),
+                )
+
+    def _test_model(self, ser_kwargs, deser_kwargs):
+        # Successful test with all of the tensors in a model
+        model = AutoModelForCausalLM.from_pretrained(model_name)
+        tensors = model.state_dict()
+
+        with tempfile.NamedTemporaryFile(
+            "wb+", delete=True, delete_on_close=False
+        ) as temporary_file:
+            serializer = TensorSerializer(
+                temporary_file, max_tensors=len(tensors), **ser_kwargs
+            )
+            for idx, (name, tensor) in enumerate(tensors.items()):
+                serializer.write_tensor(idx, name, TensorType.PARAM, tensor)
+            serializer.close()
+            with TensorDeserializer(
+                temporary_file.name,
+                verify_hash=True,
+                device="cpu",
+                **deser_kwargs,
+            ) as deserializer:
+                self.assertEqual(deserializer.keys(), tensors.keys())
+                for name in deserializer.keys():
+                    self.assertTrue(
+                        torch.equal(deserializer[name], tensors[name]),
+                        msg=(
+                            f"Contents of tensor {name!r}"
+                            " are different after deserialization"
+                        ),
+                    )
+
+    def test_model(self):
+        self._test_model({}, {})
+
+    def test_model_encryption(self):
+        encryption_params = serialization.EncryptionParams.from_string(
+            source="test"
+        )
+        decryption_params = serialization.DecryptionParams.from_string(
+            source="test"
+        )
+        self._test_model(
+            dict(encryption=encryption_params),
+            dict(encryption=decryption_params),
+        )
+
+
 @unittest.skipUnless(
     encryption_available,
     reason="libsodium must be installed to test encryption",


### PR DESCRIPTION
(note this PR is just for merging into the `v3.0.0-dev` branch, not main)

# file schema
The file schema has changed. Immediately following the metadata block is the full block of all header structures.  

After the metadata and headers is the block of raw tensor data. The block of tensor data begins on a 4k page-aligned boundary (relative to start of file). Each individual tensor begins on an 8-byte-aligned boundary.

Basically:
```
file_header
metadata_size
metadata0
...
metadataN
header0
...
headerN
tensor0 (file_offset % 4096 == 0)
tensor1 (file_offset % 8 == 0)
...
tensorN (file_offset % 8 == 0)
```
We may want to combine the metadata and the header entries, but they are left separate for now for easier backwards compatibility.

## hash computation
Previously, header hash computations included the hash fields themselves, presumed to be zeroed. This has been changed so the hash computation segments omit the hash fields.  ~This breaks `verify_hashes=True` with 2.x files for now. We should prob fix prior to release~ (This is now fixed, we can deser 2.x files with verify_hashes)

# bulk_write refactor
`_bulk_write()` has been broken up into a series of smaller functions that each perform some operation on the tensors. `_WriteSpec` carries the state of each tensor as it gets processed. Many ops are threaded and tracked as Futures (`_WriteSpec.tensor_data_task`). Dependent steps do Future chaining.

## tensor_write()
`tensor_write()`, e.g. "incremental mode", is still supported. (It is implemented as a call to `_bulk_write([tensor])`). There are new tests to validate its functionality.

### max_tensors
Because the new file schema must know ahead of time where to start writing tensor data, there must be a certain amount of pre-allocated space for the metadata and headers. Thus you must specify `max_tensors` to `TensorSerializer.__init__` If you plan on callling `tensor_write()` more than once. This does a wild-ass-guess estimate on a good amount of header space to reserve. In some cases, like really long tensor names, it could still be an underestimate. You will get a RuntimeError() if you call `write_tensor()` and there isn't enough pre-allocated space.

You do not need to set `max_tensors` if you just call `tensor_write()` once.

# Performance
Note that while these changes are mainly motivated to improve performance, I did not spend much time in this PR to measure and optimize performance. There may be regressions, but we should be able to resolve them (and beyond!) before release.