### PR TITLE
FIX: get_device method lacks MPS judgment branch

### DIFF
--- a/tensorizer/utils.py
+++ b/tensorizer/utils.py
@@ -75,7 +75,11 @@ def convert_bytes(num, decimal=True) -> str:
 
 
 def get_device() -> torch.device:
-    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    return torch.device(
+        "cuda"
+        if torch.cuda.is_available()
+        else ("mps" if torch.backends.mps.is_available() else "cpu")
+    )
 
 
 class GlobalGPUMemoryUsage(NamedTuple):


### PR DESCRIPTION
`get_device()` function in `utils.py` lacks MPS judgment branch, causing incompatibility on macOS machines.

Also sees https://github.com/coreweave/tensorizer/issues/136