### PR TITLE
fix(serialization): Track tensor encryption status per-tensor

### DIFF
--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -3834,6 +3834,7 @@ class TensorSerializer:
 
             # only used for tracking decryption during error handling
             self.decrypt_task: Optional[_Future] = None
+            self.is_currently_encrypted: bool = False
 
         @property
         def tensor_memoryview(self) -> memoryview:
@@ -4482,12 +4483,32 @@ class TensorSerializer:
                 self._jobs.extend(hash_tasks)
 
     def _do_encryption(self, write_specs: Sequence[_WriteSpec]) -> None:
-        def encrypt(write_spec, dependency: Optional[_Future]):
+        def encrypt(
+            write_spec: TensorSerializer._WriteSpec,
+            dependency: Optional[_Future],
+        ):
             if dependency is not None:
                 dependency.result(_TIMEOUT)
+            if write_spec.is_currently_encrypted:
+                raise CryptographyError("Tried to encrypt a tensor twice")
             try:
+                write_spec.is_currently_encrypted = True
                 write_spec.encryptor.encrypt_all(wait=True, timeout=_TIMEOUT)
             except _crypt.CryptographyError as e:
+                if write_spec.encryptor.num_chunks <= 1:
+                    write_spec.is_currently_encrypted = False
+                # If there were multiple chunks, the tensor is in an unclear
+                # state, since some chunks could have been encrypted while
+                # others failed.
+                # Encryption shouldn't normally be able to throw an error
+                # unless something is extremely wrong, which would presumably
+                # apply to more than just one chunk of data, so we could
+                # assume that it did not succeed for any chunks,
+                # but attempting to decrypt it anyway will skip decrypting any
+                # unencrypted chunks due to their MACs not being correct,
+                # so that is the safest option.
+                # In the future, it would be good to update `_crypt` to make
+                # `encrypt_all` report partial successes in its exception info.
                 raise CryptographyError("Tensor encryption failed") from e
             write_spec.header.update_crypt_info()
 
@@ -4604,7 +4625,11 @@ class TensorSerializer:
             )
             self._jobs.append(w.tensor_data_task)
 
-    def _maybe_decrypt_data(self, write_specs: Sequence[_WriteSpec]):
+    def _maybe_decrypt_data(
+        self,
+        write_specs: Sequence[_WriteSpec],
+        pass_through_dependency_exceptions: bool = True,
+    ):
         def decrypt(
             write_spec: TensorSerializer._WriteSpec,
             dependency: Optional[_Future],
@@ -4612,34 +4637,44 @@ class TensorSerializer:
             try:
                 if dependency is not None:
                     dependency.result(_TIMEOUT)
+            except Exception:
+                if pass_through_dependency_exceptions:
+                    raise
             finally:
-                # Try to decrypt again even if writing to disk failed
-                # to avoid exiting with the tensor memory in a modified state
-                fs = write_spec.encryptor.decrypt_all(wait=False)  # type: ignore
-                try:
-                    _crypt.ChunkedEncryption.wait_or_raise(
-                        fs,
-                        timeout=_TIMEOUT,
-                        return_when=concurrent.futures.ALL_COMPLETED,
-                    )
-                except _crypt.CryptographyError as e:
+                if write_spec.is_currently_encrypted:
+                    # Try to decrypt again even if writing to disk failed
+                    # to avoid exiting with the tensor memory still in a
+                    # modified state
+                    fs = write_spec.encryptor.decrypt_all(wait=False)
                     try:
-                        original_exc = (
-                            dependency.exception(timeout=0)
-                            if dependency is not None
-                            else None
+                        _crypt.ChunkedEncryption.wait_or_raise(
+                            fs,
+                            timeout=_TIMEOUT,
+                            return_when=concurrent.futures.ALL_COMPLETED,
                         )
-                    except (
-                        concurrent.futures.TimeoutError,
-                        concurrent.futures.CancelledError,
-                    ):
-                        original_exc = None
-                    raise CryptographyError(
-                        "Restoring encrypted tensor data in memory failed"
-                    ) from (original_exc if original_exc is not None else e)
+                        write_spec.is_currently_encrypted = False
+                    except _crypt.CryptographyError as e:
+                        try:
+                            original_exc = (
+                                dependency.exception(timeout=0)
+                                if dependency is not None
+                                else None
+                            )
+                        except (
+                            concurrent.futures.TimeoutError,
+                            concurrent.futures.CancelledError,
+                        ):
+                            original_exc = None
+                        raise CryptographyError(
+                            "Restoring encrypted tensor data in memory failed"
+                        ) from (original_exc if original_exc is not None else e)
 
         for w in write_specs:
-            if not w.user_owns_tensor_data or w.decrypt_task is not None:
+            if (
+                not w.user_owns_tensor_data
+                or w.decrypt_task is not None
+                and not w.decrypt_task.cancelled()
+            ):
                 continue
             w.tensor_data_task = self._decryption_pool.submit(
                 decrypt, w, w.tensor_data_task

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1127,9 +1127,8 @@ class TestEncryption(unittest.TestCase):
         # even in the event of an exception
         encryption = EncryptionParams.random()
         with torch.device("cpu"):
-            model = AutoModelForCausalLM.from_pretrained(
-                model_name, device_map="cpu"
-            )
+            model = AutoModelForCausalLM.from_pretrained(model_name)
+        self.assertEqual(model.device.type, "cpu")
 
         model_sd = model.state_dict()
         model_clone = {k: v.detach().clone() for k, v in model_sd.items()}

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1150,7 +1150,26 @@ class TestEncryption(unittest.TestCase):
         self._test_exception_decrypts()
 
     @patch.object(TensorSerializer, "_pwrite_syscall", raise_mock_exception)
+    @patch.object(TensorSerializer, "_pwrite_fallback", raise_mock_exception)
     def test_exception_decrypts_in_pwrite(self):
+        self._test_exception_decrypts()
+
+    @patch.object(TensorSerializer, "_do_encryption", raise_mock_exception)
+    def test_exception_decrypts_before_encryption(self):
+        self._test_exception_decrypts()
+
+    @patch.object(
+        TensorSerializer, "_prepare_for_write_encryption", raise_mock_exception
+    )
+    def test_exception_decrypts_way_before_encryption(self):
+        self._test_exception_decrypts()
+
+    @patch.object(
+        serialization._TensorHeaderSerializer,
+        "update_crypt_info",
+        raise_mock_exception,
+    )
+    def test_exception_decrypts_during_encryption(self):
         self._test_exception_decrypts()
 
 


### PR DESCRIPTION
# Track per-tensor encryption status during serialization

This PR complements #163 by adding new tests and tracking per-tensor encryption statuses during serialization to avoid attempting to decrypt tensors that aren't encrypted. Decrypting tensors that are not encrypted normally raises an exception in `tensorizer._crypt` from a MAC mismatch, which makes it fairly safe, but adds noise by spamming concerning-looking decryption errors after an initial error.

If decryption fails during error handling in a bulk write operation, its `CryptographyError` is elevated to be the top-level exception, with the previous top-level exception chained to it. Other non-`CryptographyError` exceptions from the last-ditch decryption step are ignored, since they are likely duplicates of the exception that brought the code to that error path to begin with, and the code is about to exit with an exception anyway. (If we ever get something like Python 3.11's `ExceptionGroup`s, this would be a good place to use them).