### PR TITLE
fix(stream_io): Correctly implement `readable()`/`seekable()` again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `RedisStreamFile.readable()` and `RedisStreamFile.seekable()` now correctly
+  return `True`
+
 ## [2.9.0] - 2024-04-17
 
 ### Added
@@ -400,6 +407,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `get_gpu_name`
   - `no_init_or_tensor`
 
+[Unreleased]: https://github.com/coreweave/tensorizer/compare/v2.9.0...HEAD
 [2.9.0]: https://github.com/coreweave/tensorizer/compare/v2.8.1...v2.9.0
 [2.8.1]: https://github.com/coreweave/tensorizer/compare/v2.8.0...v2.8.1
 [2.8.0]: https://github.com/coreweave/tensorizer/compare/v2.7.2...v2.8.0

--- a/tensorizer/stream_io.py
+++ b/tensorizer/stream_io.py
@@ -843,12 +843,16 @@ class RedisStreamFile(io.BufferedIOBase):
         goal_position = self._curr + size
         return self._read_until(goal_position)
 
-    @staticmethod
-    def writable() -> bool:
+    def writable(self) -> bool:
         return False
 
-    @staticmethod
-    def fileno() -> int:
+    def readable(self) -> bool:
+        return True
+
+    def seekable(self) -> bool:
+        return True
+
+    def fileno(self) -> int:
         return -1
 
     def __enter__(self):
@@ -878,7 +882,7 @@ class RedisStreamFile(io.BufferedIOBase):
             self._redis_tcp = None
         super(RedisStreamFile, self).close()  # will set self.closed to True
 
-    def readline(self):
+    def readline(self, size=-1, /):
         raise io.UnsupportedOperation("readline")
 
 


### PR DESCRIPTION
# Correct `RedisStreamFile` implementation of `io.BufferedIOBase` methods
This change repeats a fix from commit 412d0d7c154f55567d2411d9a5704c831cce050b to let `RedisStreamFile` objects be identified as readable by a `TensorDeserializer`. They were broken since they were changed to inherit from `io.BufferedIOBase` in commit b83dec7e83f4e31e8026072bf1e5763b5c6ca62b, which added dysfunctional default implementations for `readable()` and `seekable()` methods.