### PR TITLE
Fix numpy deprecation product → prod

### DIFF
--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -221,7 +221,7 @@ class TensorEntry:
         if self.data_length > 0:
             return self.data_length
         element_size: int = numpy.dtype(self.dtype).itemsize
-        num_elements: int = numpy.product(self.shape)
+        num_elements: int = numpy.prod(self.shape)
         return element_size * num_elements
 
 


### PR DESCRIPTION
`numpy.product` was deprecated in numpy 1.25, with this [PR](https://github.com/numpy/numpy/pull/23314) and removed in numpy 2.x.