### PR TITLE
tests(stream_io): Disambiguate `Expires` from `X-Amz-Expires` in regex

### DIFF
--- a/tests/test_stream_io.py
+++ b/tests/test_stream_io.py
@@ -389,7 +389,7 @@ class TestS3(unittest.TestCase):
                 r"X-Amz-Credential=[A-Z]+",
             ]
             V2_regex = [
-                r"Expires=1[0-9]+",
+                r"(?<!X-Amz-)Expires=1[0-9]+",
                 r"AWSAccessKeyId=[A-Z]+",
             ]
 


### PR DESCRIPTION
# Disambiguate URL parsing in a unit test

This change fixes a unit test that was incorrectly failing. It was essentially verifying that the string `X-Amz-Expires` was present in a URL querystring, but that `Expires` wasn't, but didn't properly account for `Expires` being a substring of `X-Amz-Expires`.
It was slightly more nuanced than this, so it didn't fail 100% of the time. This changes the regex so that the search for the substring `Expires` does not match if it is preceded by the substring `X-Amz-`.

This only fixes a unit test and does not require any updated release or changelog notes.