### PR TITLE
docs: Update dtype info

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,10 +487,13 @@ numpy, which doesn't change any of the underlying data. When serialized, the
 original `bfloat16` datatype string is also saved so that it will be cast back
 to `bfloat16` during the deserialization process.
 
-The `complex32` datatype is supported in a similar way, by casting to `int32`.
-The quantized datatypes (`qint8`, `qint32`, etc.) are not currently supported
-by tensorizer as they would require supplemental quantization parameters to be
-deserialized correctly.
+The `complex32` datatype is supported in a similar way, by casting to `int32`,
+as are PyTorch's native `float8_*` datatypes
+(`float8_e5m2`, `float8_e4m3fn`, etc.).
+
+The only native Pytorch datatypes that are not currently supported are the
+deprecated quantized int datatypes (`qint8`, `qint32`, etc.), as they require
+supplemental quantization parameters to be deserialized correctly.
 
 **NOTE:** The exact choice of intermediate types as `int16` and `int32` is
 considered an implementation detail, and is subject to change,

--- a/tensorizer/_NumpyTensor.py
+++ b/tensorizer/_NumpyTensor.py
@@ -42,6 +42,33 @@ _ALL_TYPES = {
         "bfloat16",
         "quint4x2",
         "quint2x4",
+        "bits1x8",
+        "bits2x4",
+        "bits4x2",
+        "bits8",
+        "bits16",
+        "float8_e5m2",
+        "float8_e4m3fn",
+        "float8_e5m2fnuz",
+        "float8_e4m3fnuz",
+        "uint16",
+        "uint32",
+        "uint64",
+        "uint1",
+        "uint2",
+        "uint3",
+        "uint4",
+        "uint5",
+        "uint6",
+        "uint7",
+        "int1",
+        "int2",
+        "int3",
+        "int4",
+        "int5",
+        "int6",
+        "int7",
+        "float8_e8m0fnu",
     )
     if isinstance(v := getattr(torch, t, None), torch.dtype)
 }
@@ -60,12 +87,38 @@ _ASYMMETRIC_TYPES = {
         "torch.quint4x2",
         "torch.quint2x4",
         "torch.complex32",
+        "torch.bits1x8",
+        "torch.bits2x4",
+        "torch.bits4x2",
+        "torch.bits8",
+        "torch.bits16",
+        "torch.float8_e5m2",
+        "torch.float8_e4m3fn",
+        "torch.float8_e5m2fnuz",
+        "torch.float8_e4m3fnuz",
+        "torch.uint1",
+        "torch.uint2",
+        "torch.uint3",
+        "torch.uint4",
+        "torch.uint5",
+        "torch.uint6",
+        "torch.uint7",
+        "torch.int1",
+        "torch.int2",
+        "torch.int3",
+        "torch.int4",
+        "torch.int5",
+        "torch.int6",
+        "torch.int7",
+        "torch.float8_e8m0fnu",
     }
     & _ALL_TYPES.keys()
 }
 
 # These types aren't supported yet because they require supplemental
 # quantization parameters to deserialize correctly
+# These are deprecated in PyTorch. They do not plan to add further dtypes
+# that require extra metadata to be valid as these do
 _UNSUPPORTED_TYPES = {
     _ALL_TYPES[t]
     for t in {
@@ -264,10 +317,10 @@ class _NumpyTensor(NamedTuple):
         """
         A check to see if the dtype needs to be swapped while encoding,
         based on whether numpy has a corresponding dtype or not.
-        This check is hardcoded, not dynamic, but up to date as of torch 2.0.
+        This check is hardcoded, not dynamic, but up to date as of torch 2.7.
 
         Args:
-            dtype: The torch dtype to check
+            torch_dtype: The torch dtype to check
 
         Returns:
             True if a class is known not to have a corresponding numpy dtype,


### PR DESCRIPTION
# Update `dtype` Info

This change updates the info in the README and internal lookup tables in the code to account for new dtypes introduced in PyTorch between v2.0 and v2.7.

In particular, this documents that `float8_*` and almost all other dtypes are currently supported—everything except for quantized int dtypes.

On the code side, the new dtypes were supported by a fallback mechanism before, but listing them explicitly allows them to be handled faster via table lookups. Because of that, this doesn't change what is supported, but is instead a small performance enhancement.