### PR TITLE
Add native multi-GPU device_map support to TensorDeserializer

### DIFF
--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -40,6 +40,7 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    Mapping,
     Optional,
     Sequence,
     Set,
@@ -1602,7 +1603,8 @@ class TensorDeserializer(
     Args:
         file_obj: A file-like object to read from. It can also be a string
             representing a path to a file or an HTTP/HTTPS/S3 URI.
-        device: The device to load the tensors to.
+        device: The device to load the tensors to. Acts as a fallback
+            for tensors not covered by ``device_map``.
         filter_func: A function ``(tensor_name: str) -> bool`` that returns True
             if a tensor should be loaded, or False if it should be skipped.
             If None, all tensors are loaded.
@@ -1614,6 +1616,14 @@ class TensorDeserializer(
             ``(tensor_path: str | Sequence[str | int] -> bool)`` instead.
         dtype: The dtype to cast the tensors as when loading them into a torch
             module. If None, the dtype will be inferred from the file.
+        device_map: Optional mapping of tensor names to devices, or a sequence
+            of devices for automatic balancing by tensor size.
+            When a ``Mapping``, keys are tensor names and values are target
+            devices. When a ``Sequence`` of devices, tensors are assigned
+            using a greedy largest-first strategy that places each tensor on
+            the device with the smallest accumulated byte total, balancing
+            memory across the listed devices. ``None`` (the default) places
+            all tensors on ``device``.
         lazy_load: If True, tensors will be loaded and cached when keys are
             accessed. If False, all tensors will be loaded into memory up
             front.
@@ -1692,6 +1702,12 @@ class TensorDeserializer(
         filter_func: Optional[FilterFuncType] = None,
         dtype: Optional[torch.dtype] = None,
         *,
+        device_map: Optional[
+            Union[
+                Mapping[str, Union[str, torch.device]],
+                Sequence[Union[str, torch.device]],
+            ]
+        ] = None,
         lazy_load: bool = False,
         plaid_mode: Optional[bool] = None,  # pylint: disable=unused-argument
         plaid_mode_buffers: Optional[
@@ -1896,6 +1912,12 @@ class TensorDeserializer(
                 structure.filter(self._metadata.__contains__)
             self._structure: Dict[Union[str, int], Any] = structure.dict()
 
+            self._tensor_devices: Optional[Dict[_TensorPath, torch.device]] = (
+                None
+            )
+            if device_map is not None:
+                self._tensor_devices = self._resolve_device_map(device_map)
+
             dynamic_num_readers: bool = num_readers is None
             if not dynamic_num_readers and not isinstance(num_readers, int):
                 raise TypeError(
@@ -2014,7 +2036,14 @@ class TensorDeserializer(
             # loading to the GPU, because after eager loading finishes and data
             # has been moved from the CPU to the GPU, there is no need to keep
             # around the CPU buffers anymore, and we can clean up early.
-            if self._lazy_load or not is_cuda:
+            any_cuda = is_cuda or (
+                self._tensor_devices is not None
+                and any(
+                    d.type == "cuda"
+                    for d in self._tensor_devices.values()
+                )
+            )
+            if self._lazy_load or not any_cuda:
                 self._cleanup = self._cleanup.pop_all()
 
     @property
@@ -2189,6 +2218,110 @@ class TensorDeserializer(
             return lambda timeout=None: None
 
     _preload_cuda_called: ClassVar[bool] = False
+
+    def _resolve_device_map(
+        self,
+        device_map: Union[
+            Mapping[str, Union[str, torch.device]],
+            Sequence[Union[str, torch.device]],
+        ],
+    ) -> Dict[_TensorPath, torch.device]:
+        if isinstance(device_map, str):
+            raise ValueError(
+                "device_map: expected a Mapping[str, device] or"
+                " Sequence[device], got str."
+                " Pass a list of devices instead, e.g. [\"cuda:0\", \"cuda:1\"]"
+            )
+        if isinstance(device_map, collections.abc.Mapping):
+            return self._resolve_explicit_device_map(device_map)
+        elif isinstance(device_map, collections.abc.Sequence):
+            return self._resolve_sequence_device_map(device_map)
+        else:
+            raise ValueError(
+                "device_map: expected a Mapping[str, device] or"
+                " Sequence[device], got"
+                f" {device_map.__class__.__name__}"
+            )
+
+    def _resolve_explicit_device_map(
+        self,
+        device_map: Mapping[str, Union[str, torch.device]],
+    ) -> Dict[_TensorPath, torch.device]:
+        available_names = {
+            path.normalize_(): path for path in self._metadata.keys()
+        }
+        result: Dict[_TensorPath, torch.device] = {}
+        for name, dev in device_map.items():
+            if name not in available_names:
+                available = sorted(str(k) for k in available_names.keys())
+                raise ValueError(
+                    f"device_map: tensor {name!r} not found in serialized file."
+                    f" Available tensors: {available}"
+                )
+            dev = torch.device(dev)
+            dev = self._validate_target_device(dev)
+            result[available_names[name]] = dev
+        return result
+
+    def _resolve_sequence_device_map(
+        self,
+        devices: Sequence[Union[str, torch.device]],
+    ) -> Dict[_TensorPath, torch.device]:
+        if not devices:
+            raise ValueError("device_map: sequence must not be empty")
+        resolved_devices: List[torch.device] = [
+            self._validate_target_device(torch.device(dev))
+            for dev in devices
+        ]
+
+        # Greedy largest-first balancing: sort tensors by size descending,
+        # assign each to the device with the smallest current total bytes.
+        entries = sorted(
+            (
+                (entry.deserialized_length, path)
+                for path, entry in self._metadata.items()
+            ),
+            reverse=True,
+        )
+
+        # Min-heap of [total_bytes, device_index].  Lists are used because
+        # the total_bytes element is mutated in-place before re-pushing.
+        device_loads: List[List[int]] = [
+            [0, i] for i in range(len(resolved_devices))
+        ]
+        heapq.heapify(device_loads)
+
+        result: Dict[_TensorPath, torch.device] = {}
+        for size, path in entries:
+            least_loaded = heapq.heappop(device_loads)
+            result[path] = resolved_devices[least_loaded[1]]
+            least_loaded[0] += size
+            heapq.heappush(device_loads, least_loaded)
+        return result
+
+    @staticmethod
+    def _validate_target_device(dev: torch.device) -> torch.device:
+        if dev.type == "cuda":
+            if not torch.cuda.is_available():
+                raise RuntimeError(
+                    f"device_map: cannot target {dev} because"
+                    " CUDA is not available"
+                )
+            if dev.index is None:
+                dev = torch.device("cuda", torch.cuda.current_device())
+            device_count = torch.cuda.device_count()
+            if dev.index >= device_count:
+                raise RuntimeError(
+                    f"device_map: cannot target {dev} because"
+                    f" only {device_count} CUDA"
+                    f" device{'s' * (device_count != 1)} available"
+                )
+        return dev
+
+    def _get_tensor_device(self, name: _TensorPath) -> torch.device:
+        if self._tensor_devices is not None and name in self._tensor_devices:
+            return self._tensor_devices[name]
+        return self._device
 
     def _read_single_tensor(
         self, expected_path: _TensorPath
@@ -2783,6 +2916,13 @@ class TensorDeserializer(
             raise RuntimeError(
                 "read_numpy_arrays is only valid when deserializing to the CPU"
             )
+        if self._tensor_devices is not None and any(
+            d.type != "cpu" for d in self._tensor_devices.values()
+        ):
+            raise RuntimeError(
+                "read_numpy_arrays is not supported when device_map"
+                " targets non-CPU devices"
+            )
         copied_data = self._read_numpytensors(
             filter_func=filter_func,
             num_tensors=num_tensors,
@@ -2810,18 +2950,21 @@ class TensorDeserializer(
             yield module_idx, tensor_type, name.normalize_(), arr, is_opaque, torch_dtype
 
     def _to_torch_parameter(
-        self, tensor: Union[torch.Tensor, torch.nn.Parameter]
+        self,
+        tensor: Union[torch.Tensor, torch.nn.Parameter],
+        target_device: Optional[torch.device] = None,
     ) -> torch.nn.Parameter:
         """
         Convert a tensor to a torch.nn.Parameter on a device, forcing
         gradient when appropriate. We also handle torch.nn.Parameter objects in
         a passthrough manner.
         """
+        device = target_device if target_device is not None else self._device
         original_device: torch.device = tensor.device
         if isinstance(tensor, torch.nn.Parameter):
-            tensor.data = tensor.data.to(self._device)
+            tensor.data = tensor.data.to(device)
             if tensor.grad is not None:
-                tensor.grad = tensor.grad.to(self._device)
+                tensor.grad = tensor.grad.to(device)
             return tensor
 
         # Cast the tensor if a global dtype was given to the TensorDeserializer
@@ -2837,7 +2980,7 @@ class TensorDeserializer(
         gradient = tensor.dtype.is_complex or tensor.dtype.is_floating_point
 
         start = time.perf_counter_ns() if _perf_stats else 0
-        tensor_on_device = tensor.to(device=self._device, dtype=target_dtype)
+        tensor_on_device = tensor.to(device=device, dtype=target_dtype)
         end = time.perf_counter_ns() if _perf_stats else 0
 
         result = torch.nn.Parameter(
@@ -3003,10 +3146,25 @@ class TensorDeserializer(
         # Need to get rid of self or more safely have thread-local storage
 
         try:
-            is_cuda = unsafe_self._device.type == "cuda"
-            cuda_stream = None
-            if is_cuda:
-                cuda_stream = torch.cuda.Stream(unsafe_self._device)
+            # Determine whether any tensor in this thread targets CUDA.
+            # When device_map is active, each tensor may target a
+            # different device, so we check all of them.
+            has_device_map = unsafe_self._tensor_devices is not None
+            if has_device_map:
+                is_cuda = any(
+                    unsafe_self._get_tensor_device(t.name).type == "cuda"
+                    for t in tensor_items
+                )
+            else:
+                is_cuda = unsafe_self._device.type == "cuda"
+
+            cuda_streams: Dict[torch.device, torch.cuda.Stream] = {}
+            if is_cuda and not has_device_map:
+                # Pre-create the single stream for the common case where
+                # all tensors share one CUDA device.
+                cuda_streams[unsafe_self._device] = torch.cuda.Stream(
+                    unsafe_self._device
+                )
 
             # Allocating pinned memory seems to block creating new threads, so
             # ensure all threads are created before we go
@@ -3136,16 +3294,31 @@ class TensorDeserializer(
                 is_meta = needed_buffer_size > 0 and header.data_length == 0
                 assert is_meta or needed_buffer_size == header.data_length
 
-                if is_cuda:
+                # Resolve the target device for this specific tensor.
+                # When no device_map is active, avoid the per-tensor
+                # method call and dict lookup on the hot path.
+                if has_device_map:
+                    tensor_device = unsafe_self._get_tensor_device(
+                        header.name
+                    )
+                    tensor_is_cuda = tensor_device.type == "cuda"
+                else:
+                    tensor_device = unsafe_self._device
+                    tensor_is_cuda = is_cuda
+
+                if tensor_is_cuda:
                     if is_meta:
                         shared_buffer_tensor[:needed_buffer_size].zero_()
                     mv: memoryview = shared_buffer_mv[:needed_buffer_size]
                 else:
-                    # Not in CUDA, no pinned memory.
-                    # Allocate a new buffer for each tensor
-                    # because that's what we're going to be using long-term
+                    # Allocate a dedicated CPU buffer for this tensor.
+                    # This is necessary both when no CUDA is involved and
+                    # when this tensor targets CPU while a shared pinned
+                    # buffer exists for other CUDA-targeted tensors.
                     buffer_tensor = torch.empty(
-                        (needed_buffer_size,), device="cpu", dtype=torch.uint8
+                        (needed_buffer_size,),
+                        device="cpu",
+                        dtype=torch.uint8,
                     )
                     if is_meta:
                         buffer_tensor.zero_()
@@ -3186,13 +3359,21 @@ class TensorDeserializer(
                 del mv
                 tensor = numpy_tensor.to_tensor()
 
-                stream_context = (
-                    torch.cuda.stream(cuda_stream)
-                    if is_cuda
-                    else contextlib.nullcontext()
-                )
+                if tensor_is_cuda:
+                    # Get or create a CUDA stream for this device
+                    cuda_stream = cuda_streams.get(tensor_device)
+                    if cuda_stream is None:
+                        cuda_stream = torch.cuda.Stream(tensor_device)
+                        cuda_streams[tensor_device] = cuda_stream
+                    stream_context = torch.cuda.stream(cuda_stream)
+                else:
+                    cuda_stream = None
+                    stream_context = contextlib.nullcontext()
+
                 with stream_context:
-                    parameter = unsafe_self._to_torch_parameter(tensor)
+                    parameter = unsafe_self._to_torch_parameter(
+                        tensor, target_device=tensor_device
+                    )
                     if cuda_stream is not None:
                         cuda_stream.synchronize()
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1641,3 +1641,373 @@ class TestVerification(unittest.TestCase):
                         self.assertTrue(
                             status, f"Unexpected mismatch on {tensor_name}"
                         )
+
+
+class TestDeviceMap(unittest.TestCase):
+    """Tests for the device_map parameter in TensorDeserializer."""
+
+    _serialized_model_path: str
+
+    @classmethod
+    def setUpClass(cls):
+        serialized_model_path = serialize_model(model_name, "cpu").filename
+        cls._serialized_model_path = serialized_model_path
+        gc.collect()
+
+    @classmethod
+    def tearDownClass(cls):
+        os.unlink(cls._serialized_model_path)
+
+    def _get_all_keys(self) -> list:
+        """Open a lazy probe to retrieve all tensor key names."""
+        with TensorDeserializer(
+            self._serialized_model_path, device="cpu", lazy_load=True
+        ) as probe:
+            return list(probe.keys())
+
+    def _assert_device_placement(self, deserialized, expected_device_map):
+        """Assert every tensor in deserialized sits on its expected device.
+
+        Args:
+            deserialized: An open TensorDeserializer.
+            expected_device_map: A dict mapping tensor name to expected
+                torch.device.
+        """
+        for k, v in deserialized.items():
+            expected = expected_device_map.get(k)
+            if expected is not None:
+                self.assertEqual(
+                    v.device,
+                    expected,
+                    f"Tensor {k} should be on {expected}",
+                )
+
+    def test_device_map_none_preserves_existing_behavior(self):
+        with TensorDeserializer(
+            self._serialized_model_path, device="cpu", device_map=None
+        ) as deserialized:
+            check_deserialized(self, deserialized, model_name)
+            for k, v in deserialized.items():
+                self.assertEqual(
+                    v.device,
+                    torch.device("cpu"),
+                    f"Tensor {k} should be on cpu with device_map=None",
+                )
+
+    def test_device_map_string_raises_error(self):
+        with self.assertRaises(ValueError) as ctx:
+            TensorDeserializer(
+                self._serialized_model_path,
+                device="cpu",
+                device_map="cuda:0",
+            )
+        self.assertIn("str", str(ctx.exception))
+
+    def test_device_map_wrong_type_raises_error(self):
+        with self.assertRaises(ValueError) as ctx:
+            TensorDeserializer(
+                self._serialized_model_path,
+                device="cpu",
+                device_map=42,
+            )
+        self.assertIn("int", str(ctx.exception))
+
+    def test_device_map_empty_sequence_raises_error(self):
+        with self.assertRaises(ValueError):
+            TensorDeserializer(
+                self._serialized_model_path,
+                device="cpu",
+                device_map=[],
+            )
+
+    def test_device_map_invalid_tensor_name_raises_error(self):
+        with self.assertRaises(ValueError) as ctx:
+            TensorDeserializer(
+                self._serialized_model_path,
+                device="cpu",
+                device_map={"nonexistent.tensor.name": "cpu"},
+            )
+        self.assertIn("not found", str(ctx.exception))
+        self.assertIn("Available tensors", str(ctx.exception))
+
+    def test_explicit_device_map_cpu(self):
+        all_keys = self._get_all_keys()
+        half = len(all_keys) // 2
+        device_map = {k: "cpu" for k in all_keys[:half]}
+
+        with TensorDeserializer(
+            self._serialized_model_path,
+            device="cpu",
+            device_map=device_map,
+        ) as deserialized:
+            check_deserialized(self, deserialized, model_name)
+            cpu = torch.device("cpu")
+            self._assert_device_placement(
+                deserialized, {k: cpu for k in deserialized.keys()}
+            )
+
+    def test_sequence_device_map_cpu(self):
+        with TensorDeserializer(
+            self._serialized_model_path,
+            device="cpu",
+            device_map=["cpu"],
+        ) as deserialized:
+            check_deserialized(self, deserialized, model_name)
+            for k, v in deserialized.items():
+                self.assertEqual(
+                    v.device,
+                    torch.device("cpu"),
+                    f"Tensor {k} should be on cpu",
+                )
+
+    def test_filter_func_with_device_map(self):
+        pattern = re.compile(r"transformer\.h\.0.*")
+
+        with TensorDeserializer(
+            self._serialized_model_path,
+            device="cpu",
+            filter_func=pattern.match,
+            device_map=["cpu"],
+        ) as deserialized:
+            check_deserialized(
+                self, deserialized, model_name, allow_subset=True
+            )
+            for k in deserialized.keys():
+                self.assertTrue(
+                    pattern.match(k),
+                    f"Tensor {k} should match filter pattern",
+                )
+
+    def test_lazy_load_with_device_map(self):
+        with TensorDeserializer(
+            self._serialized_model_path,
+            device="cpu",
+            device_map=["cpu"],
+            lazy_load=True,
+        ) as deserialized:
+            check_deserialized(self, deserialized, model_name)
+
+    @unittest.skipUnless(
+        is_cuda_available, reason="Requires CUDA"
+    )
+    def test_explicit_device_map_cuda(self):
+        all_keys = self._get_all_keys()
+        device_map = {k: "cuda:0" for k in all_keys}
+
+        with TensorDeserializer(
+            self._serialized_model_path,
+            device="cpu",
+            device_map=device_map,
+        ) as deserialized:
+            check_deserialized(self, deserialized, model_name)
+            cuda0 = torch.device("cuda", 0)
+            self._assert_device_placement(
+                deserialized, {k: cuda0 for k in deserialized.keys()}
+            )
+
+    @unittest.skipUnless(
+        is_cuda_available, reason="Requires CUDA"
+    )
+    def test_sequence_device_map_single_cuda(self):
+        with TensorDeserializer(
+            self._serialized_model_path,
+            device="cpu",
+            device_map=["cuda:0"],
+        ) as deserialized:
+            check_deserialized(self, deserialized, model_name)
+            for k, v in deserialized.items():
+                self.assertEqual(
+                    v.device,
+                    torch.device("cuda", 0),
+                    f"Tensor {k} should be on cuda:0",
+                )
+
+    @unittest.skipUnless(
+        torch.cuda.is_available() and torch.cuda.device_count() >= 2,
+        reason="Requires at least 2 CUDA devices",
+    )
+    def test_explicit_device_map_multi_gpu(self):
+        d0 = torch.device("cuda", 0)
+        d1 = torch.device("cuda", 1)
+        all_keys = self._get_all_keys()
+
+        device_map = {k: d0 if i % 2 == 0 else d1 for i, k in enumerate(all_keys)}
+
+        with TensorDeserializer(
+            self._serialized_model_path,
+            device="cpu",
+            device_map=device_map,
+        ) as deserialized:
+            check_deserialized(self, deserialized, model_name)
+            self._assert_device_placement(deserialized, device_map)
+
+    @unittest.skipUnless(
+        torch.cuda.is_available() and torch.cuda.device_count() >= 2,
+        reason="Requires at least 2 CUDA devices",
+    )
+    def test_sequence_device_map_multi_gpu_balanced(self):
+        d0 = torch.device("cuda", 0)
+        d1 = torch.device("cuda", 1)
+
+        with TensorDeserializer(
+            self._serialized_model_path,
+            device="cpu",
+            device_map=[d0, d1],
+        ) as deserialized:
+            check_deserialized(self, deserialized, model_name)
+
+            bytes_per_device = {d0: 0, d1: 0}
+            for k, v in deserialized.items():
+                self.assertIn(
+                    v.device,
+                    (d0, d1),
+                    f"Tensor {k} should be on cuda:0 or cuda:1",
+                )
+                bytes_per_device[v.device] += (
+                    v.element_size() * v.nelement()
+                )
+
+            total = sum(bytes_per_device.values())
+            self.assertGreater(total, 0, "No tensor bytes loaded")
+            for dev, dev_bytes in bytes_per_device.items():
+                ratio = dev_bytes / total
+                self.assertGreater(
+                    ratio,
+                    0.3,
+                    f"Device {dev} has only {ratio:.1%} of total bytes,"
+                    f" expected at least 30% for balanced distribution",
+                )
+
+    @unittest.skipUnless(
+        torch.cuda.is_available() and torch.cuda.device_count() >= 2,
+        reason="Requires at least 2 CUDA devices",
+    )
+    def test_device_map_with_multiple_readers(self):
+        d0 = torch.device("cuda", 0)
+        d1 = torch.device("cuda", 1)
+
+        for num_readers in (1, 4):
+            with self.subTest(num_readers=num_readers), TensorDeserializer(
+                self._serialized_model_path,
+                device="cpu",
+                device_map=[d0, d1],
+                num_readers=num_readers,
+            ) as deserialized:
+                check_deserialized(self, deserialized, model_name)
+
+    @unittest.skipUnless(
+        torch.cuda.is_available() and torch.cuda.device_count() >= 2,
+        reason="Requires at least 2 CUDA devices",
+    )
+    def test_device_map_fallback_device(self):
+        d0 = torch.device("cuda", 0)
+        d1 = torch.device("cuda", 1)
+        all_keys = self._get_all_keys()
+
+        # Map only the first tensor; the rest should fall back to device=d0.
+        device_map = {all_keys[0]: d1}
+        expected = {k: d0 for k in all_keys}
+        expected[all_keys[0]] = d1
+
+        with TensorDeserializer(
+            self._serialized_model_path,
+            device=d0,
+            device_map=device_map,
+        ) as deserialized:
+            check_deserialized(self, deserialized, model_name)
+            self._assert_device_placement(deserialized, expected)
+
+    def test_device_map_invalid_device(self):
+        """Verify RuntimeError when targeting a non-existent CUDA device."""
+        fake_device_index = 99
+        with self.assertRaises(RuntimeError) as ctx:
+            TensorDeserializer(
+                self._serialized_model_path,
+                device="cpu",
+                device_map=[f"cuda:{fake_device_index}"],
+            )
+        self.assertIn("device_map", str(ctx.exception))
+
+    def test_device_map_num_readers_produce_identical_values(self):
+        """num_readers=1 and num_readers=4 should produce identical tensors."""
+        results = {}
+        for num_readers in (1, 4):
+            with self.subTest(num_readers=num_readers), TensorDeserializer(
+                self._serialized_model_path,
+                device="cpu",
+                device_map=["cpu"],
+                num_readers=num_readers,
+            ) as deserialized:
+                results[num_readers] = {
+                    k: TensorInfo.from_tensor(v)
+                    for k, v in deserialized.items()
+                }
+
+        self.assertEqual(
+            results[1].keys(),
+            results[4].keys(),
+            "Keys should be identical across num_readers values",
+        )
+        for k in results[1]:
+            self.assertEqual(
+                results[1][k].hash,
+                results[4][k].hash,
+                f"Tensor {k} hash differs between num_readers=1 and num_readers=4",
+            )
+
+    @unittest.skipUnless(
+        is_cuda_available, reason="Requires CUDA"
+    )
+    def test_device_map_cpu_and_cuda_mixed(self):
+        """Mix of CPU and CUDA devices in the explicit map."""
+        all_keys = self._get_all_keys()
+        cuda_device = torch.device("cuda", 0)
+        cpu_device = torch.device("cpu")
+        device_map = {
+            k: cuda_device if i % 2 == 0 else cpu_device
+            for i, k in enumerate(all_keys)
+        }
+
+        with TensorDeserializer(
+            self._serialized_model_path,
+            device="cpu",
+            device_map=device_map,
+        ) as deserialized:
+            check_deserialized(self, deserialized, model_name)
+            self._assert_device_placement(deserialized, device_map)
+
+    @unittest.skipUnless(
+        torch.cuda.is_available() and torch.cuda.device_count() >= 2,
+        reason="Requires at least 2 CUDA devices",
+    )
+    def test_device_map_load_into_module(self):
+        """load_into_module respects device_map placement."""
+        d0 = torch.device("cuda", 0)
+        d1 = torch.device("cuda", 1)
+        all_keys = self._get_all_keys()
+
+        config = AutoConfig.from_pretrained(model_name)
+        with utils.no_init_or_tensor():
+            model = AutoModelForCausalLM.from_config(config)
+
+        device_map = {k: d0 if i % 2 == 0 else d1 for i, k in enumerate(all_keys)}
+
+        with TensorDeserializer(
+            self._serialized_model_path,
+            device="cpu",
+            device_map=device_map,
+        ) as deserialized:
+            deserialized.load_into_module(model)
+
+        # Verify each named parameter/buffer is on the device specified
+        # in the device_map, using the map lookup rather than index order.
+        named_tensors = dict(model.named_parameters())
+        named_tensors.update(model.named_buffers())
+        for name in device_map:
+            if name in named_tensors:
+                self.assertEqual(
+                    named_tensors[name].device,
+                    device_map[name],
+                    f"Parameter {name} should be on {device_map[name]}"
+                    f" after load_into_module",
+                )


### PR DESCRIPTION
Add native multi-GPU device_map support to TensorDeserializer

feat(serialization): add device_map parameter for multi-GPU tensor loading

Add native multi-GPU support to TensorDeserializer via a new device_map
keyword argument. Supports explicit per-tensor placement via a Mapping
and automatic greedy largest-first balancing via a Sequence of devices.

- Greedy balancer uses deserialized_length (bytes) with a min-heap
- Per-device CUDA streams cached in copy threads
- CPU tensors in mixed maps get dedicated buffers to avoid corruption
- Underspecified CUDA devices resolved up front
- read_numpy_arrays guarded against non-CPU device_map targets
- Default path (device_map=None) avoids per-tensor overhead in hot loop
- 19 new unit tests covering placement, balancing, fallback, edge cases