### PR TITLE
fix: bound tensor header length during deserialization

### DIFF
--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -634,6 +634,7 @@ class _TensorHeaderDeserializer:
         zero_hashes: bool = True,
         check_crypt_info: bool = False,
         long_shape_tensors: frozenset = frozenset(),
+        max_header_len: Optional[int] = None,
     ) -> Optional["_TensorHeaderDeserializer"]:
         # We read the entire header into memory rather than reading
         # it piecewise to avoid the overhead of many small reads,
@@ -643,6 +644,11 @@ class _TensorHeaderDeserializer:
         header_len: int = cls.header_len_segment.unpack(header_len_bytes)[0]
         if header_len == 0:
             return None
+        if max_header_len is not None and header_len > max_header_len:
+            raise ValueError(
+                "Tensor header length exceeds metadata bounds:"
+                f" {header_len} > {max_header_len}"
+            )
         buffer = bytearray(header_len)
         buffer[:offset] = header_len_bytes
         with memoryview(buffer) as mv:
@@ -3070,6 +3076,9 @@ class TensorDeserializer(
             tensor_sizes_by_name: Dict[_TensorPath, int] = {
                 t.name: t.deserialized_length for t in tensor_items
             }
+            metadata_by_offset: Dict[int, TensorEntry] = {
+                t.offset: t for t in unsafe_self._metadata.values()
+            }
 
             # then for each tensor in tensor_items
             tensors_read = 0
@@ -3077,11 +3086,21 @@ class TensorDeserializer(
                 if halt:
                     break
 
+                header_offset = file_.tell()
+                metadata_entry = metadata_by_offset.get(header_offset)
+                if metadata_entry is None:
+                    raise ValueError(
+                        "Unexpected tensor header offset:"
+                        f" {header_offset}"
+                    )
+
                 header = _TensorHeaderDeserializer.from_io(
                     file_,
                     zero_hashes=True,
                     check_crypt_info=unsafe_self._has_crypt_info,
                     long_shape_tensors=unsafe_self._long_shape_tensors,
+                    max_header_len=metadata_entry.data_offset
+                    - metadata_entry.offset,
                 )
 
                 if header is None:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -10,6 +10,7 @@ import logging
 import os
 import re
 import secrets
+import struct
 import sys
 import tempfile
 import time
@@ -344,6 +345,40 @@ class TestSerialization(unittest.TestCase):
                     del deserialized
                 finally:
                     os.unlink(serialized_model)
+
+    def test_oversized_tensor_header_is_rejected(self):
+        with temporary_file("wb+") as tensorized_file:
+            serializer = TensorSerializer(tensorized_file)
+            serializer.write_state_dict({"tensor": torch.zeros(1)})
+            serializer.close()
+
+            with TensorDeserializer(
+                tensorized_file.name,
+                device="cpu",
+                lazy_load=True,
+                num_readers=1,
+            ) as deserializer:
+                entry = deserializer._metadata[("tensor",)]
+
+            with open(tensorized_file.name, "rb") as file:
+                data = bytearray(file.read())
+
+            legal_header_len = entry.data_offset - entry.offset
+            struct.pack_into(
+                "<Q", data, entry.offset, legal_header_len + 1
+            )
+            with open(tensorized_file.name, "wb") as file:
+                file.write(data)
+
+            with TensorDeserializer(
+                tensorized_file.name,
+                device="cpu",
+                lazy_load=True,
+                num_readers=1,
+            ) as deserializer, self.assertRaisesRegex(
+                ValueError, "Tensor header length exceeds metadata bounds"
+            ):
+                deserializer["tensor"]
 
     def test_large_unbuffered_tensor(self):
         shape = (36000, 36000)  # 4.828 GiB


### PR DESCRIPTION
## Summary

Bounds each tensor header length against the metadata span that already describes where that tensor's data begins.

Before this change, `_TensorHeaderDeserializer.from_io()` trusted the 8-byte header length stored in the file and allocated a `bytearray(header_len)` before checking whether that length fit the metadata entry for the tensor. A malformed `.tensors` file could therefore make the lazy deserializer allocate based on an attacker-controlled header length, and small oversized headers could also be accepted because missing bytes were effectively padded in the header buffer.

## Fix

- Add an optional `max_header_len` guard to `_TensorHeaderDeserializer.from_io()`.
- In `_copy_thread()`, derive the legal header span from the metadata entry at the current file offset: `entry.data_offset - entry.offset`.
- Reject unexpected header offsets and oversized header lengths before allocating the header buffer.

## Tests

- `python -m py_compile tensorizer\serialization.py tests\test_serialization.py`
- `python -m pytest tests\test_serialization.py::TestSerialization::test_oversized_tensor_header_is_rejected -q`
- `python -m pytest tests\test_serialization.py::TestDeserialization::test_lazy_load -q`
- `python -m pytest tests\test_serialization.py::TestSerialization::test_oversized_tensor_header_is_rejected tests\test_serialization.py::TestDeserialization::test_lazy_load -q`
- `git diff --check`

`test_lazy_load` emits the existing Hugging Face cache symlink warning on Windows, but passes.
