### PR TITLE
docs: fix duplicated "the" in benchmark README

### DIFF
--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -9,7 +9,7 @@ and [HuggingFace Transformers](https://huggingface.co/docs/transformers/index).
 
 As configured, the benchmark job will deserialize
 [OPT-30B](https://huggingface.co/facebook/opt-30b) 100 times using each library.
-This can be reconfigured by changing the the `MODEL_ID` and `MODEL_PATH`
+This can be reconfigured by changing the `MODEL_ID` and `MODEL_PATH`
 environment variables described under [Serialization](#serialization)
 and [Deserialization](#deserialization) below.
 


### PR DESCRIPTION
Small documentation fix: `examples/benchmark/README.md` had a duplicated word ("changing the the `MODEL_ID`"). Removed the extra "the" so the sentence reads correctly. No functional changes.